### PR TITLE
Cleanup connection class

### DIFF
--- a/libkodimote/kodiconnection.cpp
+++ b/libkodimote/kodiconnection.cpp
@@ -450,23 +450,15 @@ int KodiConnectionPrivate::sendCommand(const QString &command, const QVariant &p
 
 int KodiConnectionPrivate::sendCommand(const QString &command, const QVariant &params, QObject *callbackReceiver, const QString &callbackMember)
 {
-    if(!(m_connected || m_connecting)) {
-        qDebug() << "Not connected. Discarding command" << command;
-        return -1;
+    int id = sendCommand(command, params);
+
+    //reply can't be handled until the next event loop iteration,
+    //so it's save to make the call before registering the callback
+    if (id >= 0) {
+        Callback callback(callbackReceiver, callbackMember);
+        m_callbacks.insert(id, callback);
     }
 
-    int id = m_commandId++;
-
-    Callback callback(callbackReceiver, callbackMember);
-    m_callbacks.insert(id, callback);
-
-    Command cmd(id, command, params);
-    m_commandQueue.append(cmd);
-    sendNextCommand();
-
-    if(m_commandId < 0) {
-        m_commandId = 0;
-    }
     return id;
 }
 

--- a/libkodimote/kodiconnection.cpp
+++ b/libkodimote/kodiconnection.cpp
@@ -125,7 +125,6 @@ KodiConnectionPrivate::KodiConnectionPrivate(QObject *parent) :
     QObject::connect(m_connManager, SIGNAL(onlineStateChanged(bool)), SLOT(connect()));
 
     QObject::connect(m_socket, SIGNAL(readyRead()), SLOT(readData()));
-//    QObject::connect(m_socket, SIGNAL(connected()), m_notifier, SIGNAL(connectionChanged()));
     QObject::connect(m_socket, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(socketError()));
     QObject::connect(m_socket, SIGNAL(connected()), SLOT(slotConnected()));
     QObject::connect(m_socket, SIGNAL(disconnected()), SLOT(slotDisconnected()));
@@ -315,10 +314,8 @@ void KodiConnectionPrivate::sendNextCommand() {
         QByteArray data = serializer.serialize(map);
 #endif
 
-//        koDebug(XDAREA_CONNECTION) << "ater serializing:" << data;
         QString dataStr = QString::fromLatin1(data);
 #ifdef DEBUGJSON
-//        koDebug(XDAREA_CONNECTION) << "sending command 1" << dataStr;
         koDebug(XDAREA_CONNECTION) << "sending command to" << request.url() << ":" << dataStr.toLocal8Bit();
 #endif
         QNetworkReply * reply = m_network->post(request, data);
@@ -432,7 +429,6 @@ void KodiConnectionPrivate::replyReceived()
         }
 
         if(m_currentPendingCommand.id() == id) {
-//            m_commandQueue.removeFirst();
             m_timeoutTimer.stop();
             m_currentPendingCommand = Command();
         }
@@ -483,7 +479,6 @@ int KodiConnectionPrivate::sendCommand(const QString &command, const QVariant &p
 
 void KodiConnectionPrivate::readData()
 {
-//    QString data = QString::fromUtf8(m_socket->readAll());
     QByteArray dataArray = m_socket->readAll();
     QString data(dataArray);
     koDebug(XDAREA_CONNECTION) << "<<<<<<<<<<<< Received:" << dataArray;
@@ -652,7 +647,6 @@ void KodiConnectionPrivate::downloadProgress(qint64 progress, qint64 total)
 {
     QNetworkReply *reply = static_cast<QNetworkReply*>(sender());
     KodiDownload *download = m_activeDownloadsMap.value(reply);
-//    qDebug() << "updating progress:" << progress << "/" << total;
     download->setTotal(total);
     download->setProgress(progress);
 }
@@ -716,7 +710,6 @@ void KodiConnectionPrivate::authenticationRequired(QNetworkReply *reply, QAuthen
         m_connectionError = "Wrong username or password";
         m_lastAuthRequest = 0;
         m_host->setPassword(QString());
-//        emit m_notifier->authenticationRequired(m_host->hostname(), m_host->address());
     }
     if(!m_host->username().isEmpty() && !m_host->password().isEmpty()) {
         authenticator->setUser(m_host->username());

--- a/libkodimote/kodiconnection.h
+++ b/libkodimote/kodiconnection.h
@@ -42,7 +42,6 @@ QString connectionError();
 
 int sendCommand(const QString &command, const QVariant &params = QVariant());
 int sendCommand(const QString &command, const QVariant &params, QObject *callbackReceiver, const QString &callbackMember);
-void sendLegacyCommand(const QString &command);
 
 QNetworkAccessManager *nam();
 

--- a/libkodimote/kodiconnection_p.h
+++ b/libkodimote/kodiconnection_p.h
@@ -107,6 +107,7 @@ private slots:
     void slotDisconnected();
     void internalConnect();
     void sessionLost();
+    void versionReceived(const QVariantMap &rsp);
 
     void replyReceived();
     void authenticationRequired(QNetworkReply *reply, QAuthenticator *authenticator);

--- a/libkodimote/kodiconnection_p.h
+++ b/libkodimote/kodiconnection_p.h
@@ -134,6 +134,7 @@ private:
 
     void sendNextCommand();
     void handleData(const QString &data);
+    void closeConnection();
 
     KodiHost *m_host;
 

--- a/libkodimote/kodiconnection_p.h
+++ b/libkodimote/kodiconnection_p.h
@@ -133,6 +133,7 @@ private:
     QTimer m_reconnectTimer;
 
     void sendNextCommand();
+    void handleData(const QString &data);
 
     KodiHost *m_host;
 

--- a/libkodimote/kodiconnection_p.h
+++ b/libkodimote/kodiconnection_p.h
@@ -90,7 +90,6 @@ public:
 
     int sendCommand(const QString &command, const QVariant &parms = QVariant());
     int sendCommand(const QString &command, const QVariant &params, QObject *callbackReceiver, const QString &callbackMember);
-    void sendLegacyCommand(const QString &command);
 
     QNetworkAccessManager *nam();
     Notifier *notifier();
@@ -133,7 +132,6 @@ private:
     QTimer m_reconnectTimer;
 
     void sendNextCommand();
-    void sendNextCommand2();
 
     KodiHost *m_host;
 


### PR DESCRIPTION
These changes don't change any behavior, but they do clean up a lot of old/unused and duplicate code in the connection class. So the main purpose is to make it easier to maintain the class.

NOTE: Contains commit of #1 so same warning applies. These changes can be reviewed, but please hold of merging until I've figured out what is the best way to do the rename.