### PR TITLE
Add support for switching profiles (Sailfish only)

### DIFF
--- a/apps/sailfish/qml/pages/KodiPage.qml
+++ b/apps/sailfish/qml/pages/KodiPage.qml
@@ -66,6 +66,10 @@ Page {
         ListModel {
             id: kodiMenuModelTemplate
             ListElement {
+                icon: "image://theme/icon-l-people"
+                target: "changeUser"
+            }
+            ListElement {
                 icon: "image://theme/icon-l-dismiss"
                 target: "quit"
             }
@@ -95,6 +99,9 @@ Page {
 
                 if (item) {
                     var target = kodiMenuModel.get(index).target;
+                    if (target === "changeUser") {
+                        return qsTr("Change user");
+                    }
                     if (target === "quit") {
                         return qsTr("Quit");
                     }
@@ -122,7 +129,10 @@ Page {
                 }
 
                 var target = kodiMenuModel.get(index).target;
-                if (target === "quit") {
+                if (target === "changeUser") {
+                    pageStack.push("ProfileSelectionDialog.qml");
+                }
+                else if (target === "quit") {
                     kodi.quit();
                 }
                 else if (target === "shutdown") {
@@ -143,18 +153,21 @@ Page {
 
     function populateKodiMenu() {
         kodiMenuModel.clear();
-        kodiMenuModel.append(kodiMenuModelTemplate.get(0));
-        if (kodi.canShutdown) {
-            kodiMenuModel.append(kodiMenuModelTemplate.get(1));
+        if (kodi.profiles().count > 1) {
+            kodiMenuModel.append(kodiMenuModelTemplate.get(0));
         }
-        if (kodi.canReboot) {
+        kodiMenuModel.append(kodiMenuModelTemplate.get(1));
+        if (kodi.canShutdown) {
             kodiMenuModel.append(kodiMenuModelTemplate.get(2));
         }
-        if (kodi.canShutdown) {
+        if (kodi.canReboot) {
             kodiMenuModel.append(kodiMenuModelTemplate.get(3));
         }
-        if (kodi.canHibernate) {
+        if (kodi.canShutdown) {
             kodiMenuModel.append(kodiMenuModelTemplate.get(4));
+        }
+        if (kodi.canHibernate) {
+            kodiMenuModel.append(kodiMenuModelTemplate.get(5));
         }
     }
 
@@ -165,5 +178,10 @@ Page {
     Connections {
         target: kodi
         onSystemPropertiesChanged: populateKodiMenu();
+    }
+
+    Connections {
+        target: kodi.profiles()
+        onCountChanged: populateKodiMenu();
     }
 }

--- a/apps/sailfish/qml/pages/ProfileSelectionDialog.qml
+++ b/apps/sailfish/qml/pages/ProfileSelectionDialog.qml
@@ -1,0 +1,82 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import harbour.kodimote 1.0
+
+Dialog {
+    onAccepted: {
+        listView.model.switchProfile(listView.currentIndex)
+    }
+
+    Connections {
+        target: listView.model
+        onCurrentProfileIndexChanged: {
+            if (listView.currentIndex === -1) {
+                listView.currentIndex = listView.model.currentProfileIndex;
+            }
+        }
+    }
+
+    BusyIndicator {
+        id: busyIndicator
+        anchors.centerIn: parent
+        running: listView.model.busy
+        visible: listView.model.busy
+        size: BusyIndicatorSize.Large
+    }
+
+    SilicaListView {
+        id: listView
+        anchors.fill: parent
+        model: kodi.profiles();
+        currentIndex: model.currentProfileIndex
+
+        header: DialogHeader {
+            acceptText: qsTr("Select user")
+        }
+
+        delegate: ListItem {
+            width: listView.width
+            height: Theme.itemSizeLarge
+            contentHeight: height
+
+            highlighted: down || listView.currentIndex === index
+
+            onClicked: {
+                listView.currentIndex = index
+            }
+
+            Label {
+                text: title
+                anchors.margins: Theme.paddingLarge
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+
+                font.weight: Font.Bold
+                font.pixelSize: Theme.fontSizeMedium
+                elide: Text.ElideRight
+            }
+        }
+    }
+}

--- a/apps/sailfish/sailfish.pro
+++ b/apps/sailfish/sailfish.pro
@@ -51,5 +51,6 @@ OTHER_FILES += \
     qml/pages/KodiPage.qml \
     qml/components/ChannelDetails.qml \
     qml/components/DockedControls.qml \
-    qml/components/ControlsMenuItem.qml
+    qml/components/ControlsMenuItem.qml \
+    qml/pages/ProfileSelectionDialog.qml
 

--- a/libkodimote/kodi.cpp
+++ b/libkodimote/kodi.cpp
@@ -37,6 +37,7 @@
 #include "channels.h"
 #include "channelbroadcasts.h"
 #include "pvrmenu.h"
+#include "profiles.h"
 
 #include "playlist.h"
 #include "audioplaylist.h"
@@ -153,6 +154,7 @@ Kodi::Kodi(QObject *parent) :
     qmlRegisterType<Channels>();
     qmlRegisterType<ChannelBroadcasts>();
     qmlRegisterType<PvrMenu>();
+    qmlRegisterType<Profiles>();
     qmlRegisterType<Keys>();
     qmlRegisterType<EventClient>();
     qmlRegisterType<KodiFilterModel>(qmlUri, 1, 0, "KodiFilterModel");
@@ -183,6 +185,7 @@ Kodi::Kodi(QObject *parent) :
 
     m_keys = new Keys(this);
     m_eventClient = new EventClient(this);
+    m_profiles = new Profiles(this);
 
     m_volumeAnimation.setTargetObject(this);
     m_volumeAnimation.setPropertyName("volume");
@@ -226,6 +229,8 @@ void Kodi::init()
         m_hwAddrRequestCount = 0;
         requestHwAddr();
     }
+
+    m_profiles->refresh();
 }
 
 void Kodi::slotDownloadAdded(KodiDownload *download)
@@ -301,6 +306,11 @@ Shares *Kodi::shares(const QString &mediatype)
 PvrMenu *Kodi::pvrMenu()
 {
     return new PvrMenu();
+}
+
+Profiles *Kodi::profiles()
+{
+    return m_profiles;
 }
 
 AudioPlayer *Kodi::audioPlayer()

--- a/libkodimote/kodi.h
+++ b/libkodimote/kodi.h
@@ -33,6 +33,7 @@ class VideoLibrary;
 class Shares;
 class ChannelGroups;
 class PvrMenu;
+class Profiles;
 
 class Player;
 class AudioPlayer;
@@ -89,6 +90,7 @@ public:
 
     Q_INVOKABLE Shares *shares(const QString &mediatype);
     Q_INVOKABLE PvrMenu *pvrMenu();
+    Q_INVOKABLE Profiles *profiles();
 
     Q_INVOKABLE AudioPlayer *audioPlayer();
     Q_INVOKABLE VideoPlayer *videoPlayer();
@@ -207,6 +209,7 @@ private:
     QString m_username;
     QString m_password;
     KodiHostModel *m_hosts;
+    Profiles *m_profiles;
 
     int m_originalVolume;
     int m_targetVolume;

--- a/libkodimote/kodimodel.cpp
+++ b/libkodimote/kodimodel.cpp
@@ -173,6 +173,7 @@ QHash<int, QByteArray> KodiModel::roleNames() const
     roleNames.insert(RolePlaycount, "playcount");
     roleNames.insert(RoleCast, "cast");
     roleNames.insert(RolePlayingState, "playingState");
+    roleNames.insert(RoleLockMode, "lockMode");
     return roleNames;
 }
 

--- a/libkodimote/kodimodel.h
+++ b/libkodimote/kodimodel.h
@@ -30,6 +30,7 @@ class KodiModel : public QAbstractItemModel
 {
     Q_OBJECT
     Q_ENUMS(ThumbnailFormat)
+    Q_ENUMS(LockMode)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(int count READ rowCount NOTIFY layoutChanged)
     Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
@@ -82,7 +83,8 @@ public:
         RoleComment,
         RolePlaycount,
         RoleCast,
-        RolePlayingState
+        RolePlayingState,
+        RoleLockMode
     };
 
     enum ThumbnailFormat {
@@ -97,6 +99,13 @@ public:
         ItemIdInvalid = -1,
         ItemIdRecentlyAdded = -2,
         ItemIdRecentlyPlayed = -3
+    };
+
+    enum LockMode {
+        LockModeNone = 0,
+        LockModeNumeric = 1,
+        LockModeGamePad = 2,
+        LockModeAlphaNumeric = 3
     };
 
     explicit KodiModel(KodiModel *parent);

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -71,9 +71,10 @@ SOURCES +=  kodi.cpp \
 	    channelitem.cpp \
 	    channelbroadcasts.cpp \
 	    recordings.cpp \
-	    pvrmenu.cpp \
+            pvrmenu.cpp \
             kodihost.cpp \
-            addonsource.cpp
+            addonsource.cpp \
+            profiles.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -125,7 +126,8 @@ HEADERS += libkodimote_global.h \
 	   recentitems.h \
 	   channelitem.h \
 	   channelbroadcasts.h \
-	   recordings.h \
+           recordings.h \
 	   pvrmenu.h \
            kodihost.h \
-           addonsource.h
+           addonsource.h \
+           profiles.h

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -70,11 +70,12 @@ SOURCES +=  kodi.cpp \
 	    recentitems.cpp \
 	    channelitem.cpp \
 	    channelbroadcasts.cpp \
-	    recordings.cpp \
+            recordings.cpp \
             pvrmenu.cpp \
             kodihost.cpp \
             addonsource.cpp \
-            profiles.cpp
+            profiles.cpp \
+            profileitem.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -130,4 +131,5 @@ HEADERS += libkodimote_global.h \
 	   pvrmenu.h \
            kodihost.h \
            addonsource.h \
-           profiles.h
+           profiles.h \
+           profileitem.h

--- a/libkodimote/profileitem.cpp
+++ b/libkodimote/profileitem.cpp
@@ -19,39 +19,29 @@
  *                                                                           *
  ****************************************************************************/
 
-#ifndef PROFILES_H
-#define PROFILES_H
+#include "profileitem.h"
 
-#include "kodimodel.h"
-
-class Profiles : public KodiModel
+ProfileItem::ProfileItem(QObject *parent) :
+    KodiModelItem(parent), m_lockMode(KodiModel::LockModeNone)
 {
-    Q_OBJECT
-    Q_PROPERTY(QString currentProfile READ currentProfile NOTIFY currentProfileChanged)
-    Q_PROPERTY(int currentProfileIndex READ currentProfileIndex NOTIFY currentProfileChanged)
-    Q_PROPERTY(int count READ count NOTIFY countChanged)
-public:
-    explicit Profiles(QObject *parent = 0);
+}
 
-    int count() const;
-    QString currentProfile() const;
-    int currentProfileIndex() const;
-    Q_INVOKABLE QString title() const;
+KodiModel::LockMode ProfileItem::lockMode() const
+{
+    return m_lockMode;
+}
 
-signals:
-    void countChanged();
-    void currentProfileChanged();
+void ProfileItem::setLockMode(KodiModel::LockMode lockMode)
+{
+    m_lockMode = lockMode;
+    emit lockModeChanged();
+}
 
-public slots:
-    void refresh();
-    void switchProfile(int index, const QString &lockCode = QString());
+QVariant ProfileItem::data(int role) const
+{
+    if (role == KodiModel::RoleLockMode) {
+        return m_lockMode;
+    }
 
-private:
-    QString m_currentProfile;
-
-private slots:
-    void currentProfileReceived(const QVariantMap &rsp);
-    void listReceived(const QVariantMap &rsp);
-};
-
-#endif // PROFILES_H
+    return KodiModelItem::data(role);
+}

--- a/libkodimote/profileitem.h
+++ b/libkodimote/profileitem.h
@@ -19,39 +19,31 @@
  *                                                                           *
  ****************************************************************************/
 
-#ifndef PROFILES_H
-#define PROFILES_H
+#ifndef PROFILEITEM_H
+#define PROFILEITEM_H
+
+#include "kodimodelitem.h"
 
 #include "kodimodel.h"
 
-class Profiles : public KodiModel
+class ProfileItem : public KodiModelItem
 {
     Q_OBJECT
-    Q_PROPERTY(QString currentProfile READ currentProfile NOTIFY currentProfileChanged)
-    Q_PROPERTY(int currentProfileIndex READ currentProfileIndex NOTIFY currentProfileChanged)
-    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(KodiModel::LockMode lockMode READ lockMode WRITE setLockMode NOTIFY lockModeChanged)
 public:
-    explicit Profiles(QObject *parent = 0);
 
-    int count() const;
-    QString currentProfile() const;
-    int currentProfileIndex() const;
-    Q_INVOKABLE QString title() const;
+    explicit ProfileItem(QObject *parent = 0);
+
+    KodiModel::LockMode lockMode() const;
+    void setLockMode(KodiModel::LockMode lockMode);
+
+    virtual QVariant data(int role) const;
 
 signals:
-    void countChanged();
-    void currentProfileChanged();
-
-public slots:
-    void refresh();
-    void switchProfile(int index, const QString &lockCode = QString());
+    void lockModeChanged();
 
 private:
-    QString m_currentProfile;
-
-private slots:
-    void currentProfileReceived(const QVariantMap &rsp);
-    void listReceived(const QVariantMap &rsp);
+    KodiModel::LockMode m_lockMode;
 };
 
-#endif // PROFILES_H
+#endif // PROFILEITEM_H

--- a/libkodimote/profiles.cpp
+++ b/libkodimote/profiles.cpp
@@ -1,0 +1,108 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
+#include "profiles.h"
+
+#include <QTimer>
+
+#include "kodiconnection.h"
+#include "libraryitem.h"
+
+Profiles::Profiles(QObject *parent) :
+    KodiModel(parent)
+{
+}
+
+QString Profiles::title() const
+{
+    return tr("Profiles");
+}
+
+int Profiles::count() const
+{
+    return m_list.size();
+}
+
+void Profiles::switchProfile(int index)
+{
+    if (index < 0 || index > m_list.size()) {
+        return;
+    }
+
+    KodiModelItem *item = m_list.at(index);
+    QVariantMap params;
+    params.insert("profile", item->title());
+    params.insert("prompt", true);
+
+    KodiConnection::sendCommand("Profiles.LoadProfile", params);
+}
+
+void Profiles::refresh()
+{
+    KodiConnection::sendCommand("Profiles.GetProfiles", QVariantMap(), this, "listReceived");
+
+    KodiConnection::sendCommand("Profiles.GetCurrentProfile", QVariantMap(), this, "currentProfileReceived");
+}
+
+void Profiles::currentProfileReceived(const QVariantMap &rsp)
+{
+    QString currentProfile = rsp.value("result").toMap().value("label").toString();
+    if (m_currentProfile != currentProfile) {
+        m_currentProfile = currentProfile;
+        emit currentProfileChanged();
+    }
+}
+
+QString Profiles::currentProfile() const
+{
+    return m_currentProfile;
+}
+
+int Profiles::currentProfileIndex() const
+{
+    int size = m_list.size();
+    for (int i = 0; i < size; i++) {
+        if (m_list.at(i)->title() == m_currentProfile) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+void Profiles::listReceived(const QVariantMap &rsp)
+{
+    QList<KodiModelItem*> list;
+    QVariantList responseList = rsp.value("result").toMap().value("profiles").toList();
+    foreach(const QVariant &itemVariant, responseList) {
+        QVariantMap itemMap = itemVariant.toMap();
+        KodiModelItem *item = new KodiModelItem(this);
+        item->setTitle(itemMap.value("label").toString());
+
+        list.append(item);
+    }
+
+    beginResetModel();
+    m_list = list;
+    endResetModel();
+    setBusy(false);
+    emit countChanged();
+}

--- a/libkodimote/profiles.h
+++ b/libkodimote/profiles.h
@@ -1,0 +1,57 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
+#ifndef PROFILES_H
+#define PROFILES_H
+
+#include "kodimodel.h"
+
+class Profiles : public KodiModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QString currentProfile READ currentProfile NOTIFY currentProfileChanged)
+    Q_PROPERTY(int currentProfileIndex READ currentProfileIndex NOTIFY currentProfileChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+public:
+    explicit Profiles(QObject *parent = 0);
+
+    int count() const;
+    QString currentProfile() const;
+    int currentProfileIndex() const;
+    Q_INVOKABLE QString title() const;
+
+signals:
+    void countChanged();
+    void currentProfileChanged();
+
+public slots:
+    void refresh();
+    void switchProfile(int index);
+
+private:
+    QString m_currentProfile;
+
+private slots:
+    void currentProfileReceived(const QVariantMap &rsp);
+    void listReceived(const QVariantMap &rsp);
+};
+
+#endif // PROFILES_H


### PR DESCRIPTION
Add support for switching profiles (lib + Sailfish only). Drawback is that the servers in XBMC/Kodi are bound to the profile, so the servers will restart during the switch, which means the connection gets dropped. Automatic reconnecting doesn't happen as we don't run the reconnect timer when the server disconnects. This is something that will be addressed in another branch/merge request.

NOTE: includes #1, so review only.