### PR TITLE
Optimize image downloading

### DIFF
--- a/libkodimote/imagecache.h
+++ b/libkodimote/imagecache.h
@@ -43,10 +43,7 @@ class KodiImageCache : public QThread
 public:
     explicit KodiImageCache(QObject *parent = 0);
     
-    bool contains(const QString &image, int cacheId);
-    QString cachedFile(const QString &image, int cacheId);
-
-    static QString cachePath(int cacheId);
+    bool contains(const QString &image, int cacheId, QString &cachedFile);
 
     void run();
 
@@ -70,7 +67,9 @@ private slots:
 
     void cleanupAndTriggerNext();
 private:
-    QString cacheKey(const QString &image, int cacheId);
+    static QString cacheKey(const QString &image, int cacheId);
+    static QString cachedFile(const QString &path, const QString &image);
+    static QString cachePath(int cacheId);
 
     int m_jobId;
 
@@ -80,7 +79,7 @@ private:
     QMutex m_mutex;
     QTimer *m_fetchNextTimer;
 
-    QList<QHash<QString, bool> > m_cacheFiles;
+    QHash<QString, QPair<bool, QString> > m_cacheFiles;
 
     bool m_doubleDecode;
 };

--- a/libkodimote/imagecache.h
+++ b/libkodimote/imagecache.h
@@ -62,10 +62,8 @@ public slots:
 private slots:
     void imageFetched();
 
-    void fetchNext();
+    void fetchNext(ImageFetchJob *job);
     void downloadPrepared(const QVariantMap &map);
-
-    void cleanupAndTriggerNext();
 private:
     static QString cacheKey(const QString &image, int cacheId);
     static QString cachedFile(const QString &path, const QString &image);
@@ -73,13 +71,11 @@ private:
 
     int m_jobId;
 
-    ImageFetchJob *m_currentJob;
-    QList<QString> m_downloadQueue;
     QHash<QString, ImageFetchJob*> m_jobs;
     QMutex m_mutex;
-    QTimer *m_fetchNextTimer;
 
     QHash<QString, QPair<bool, QString> > m_cacheFiles;
+    QHash<int, QString> m_fetchQueue;
 
     bool m_doubleDecode;
 };

--- a/libkodimote/imagecache.h
+++ b/libkodimote/imagecache.h
@@ -37,15 +37,13 @@ class ImageFetchJob;
 class QFile;
 
 // Can't be ImageCache because invoker on Harmattan causes a name-clash and breaks method-invokation
-class KodiImageCache : public QThread
+class KodiImageCache : public QObject
 {
     Q_OBJECT
 public:
     explicit KodiImageCache(QObject *parent = 0);
     
     bool contains(const QString &image, int cacheId, QString &cachedFile);
-
-    void run();
 
 public slots:
     /**
@@ -64,6 +62,7 @@ private slots:
 
     void fetchNext(ImageFetchJob *job);
     void downloadPrepared(const QVariantMap &map);
+    void imageScaled();
 private:
     static QString cacheKey(const QString &image, int cacheId);
     static QString cachedFile(const QString &path, const QString &image);
@@ -72,7 +71,6 @@ private:
     int m_jobId;
 
     QHash<QString, ImageFetchJob*> m_jobs;
-    QMutex m_mutex;
 
     QHash<QString, QPair<bool, QString> > m_cacheFiles;
     QHash<int, QString> m_fetchQueue;

--- a/libkodimote/kodi.cpp
+++ b/libkodimote/kodi.cpp
@@ -187,8 +187,6 @@ Kodi::Kodi(QObject *parent) :
     m_volumeAnimation.setTargetObject(this);
     m_volumeAnimation.setPropertyName("volume");
     m_volumeAnimation.setDuration(500);
-
-    m_imageCache->start(QThread::IdlePriority);
 }
 
 Kodi::~Kodi()

--- a/libkodimote/kodimodel.cpp
+++ b/libkodimote/kodimodel.cpp
@@ -60,8 +60,9 @@ QVariant KodiModel::data(const QModelIndex &index, int role) const
         if(thumbnail.isEmpty()) {
             return QString();
         }
-        if(Kodi::instance()->imageCache()->contains(thumbnail, 0)) {
-            return Kodi::instance()->imageCache()->cachedFile(thumbnail, 0);
+        QString cachedFile;
+        if(Kodi::instance()->imageCache()->contains(thumbnail, 0, cachedFile)) {
+            return cachedFile;
         }
         // Size optimized for list view icons.
         int job = Kodi::instance()->imageCache()->fetch(thumbnail, const_cast<KodiModel*>(this), "imageFetched", QSize(152, 120), 0);
@@ -73,8 +74,9 @@ QVariant KodiModel::data(const QModelIndex &index, int role) const
         if(thumbnail.isEmpty()) {
             return QString();
         }
-        if(Kodi::instance()->imageCache()->contains(thumbnail, 1)) {
-            return Kodi::instance()->imageCache()->cachedFile(thumbnail, 1);
+        QString cachedFile;
+        if(Kodi::instance()->imageCache()->contains(thumbnail, 1, cachedFile)) {
+            return cachedFile;
         }
         // Size optimized for big representations.
         int job = Kodi::instance()->imageCache()->fetch(thumbnail, const_cast<KodiModel*>(this), "imageFetched", QSize(1000, 1000), 1);

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -1,8 +1,9 @@
+Qt += concurent network
 contains(QT_VERSION, ^5\\..\\..*) {
     DEFINES += QT5_BUILD
-    QT += network quick qml
+    QT += quick qml
 } else {
-    QT += network declarative
+    QT += declarative
 }
 
 packagesExist(sailfishapp) {

--- a/libkodimote/libraryitem.cpp
+++ b/libkodimote/libraryitem.cpp
@@ -191,8 +191,9 @@ QString LibraryItem::thumbnail() const
         return QString();
     }
 
-    if(Kodi::instance()->imageCache()->contains(m_thumbnail, 1)) {
-        return Kodi::instance()->imageCache()->cachedFile(m_thumbnail, 1);
+    QString cachedFile;
+    if(Kodi::instance()->imageCache()->contains(m_thumbnail, 1, cachedFile)) {
+        return cachedFile;
     }
     // scaleTo size optimized for big representations.
     int id = Kodi::instance()->imageCache()->fetch(m_thumbnail, const_cast<LibraryItem*>(this), "imageFetched", QSize(1000, 1000), 1);
@@ -208,8 +209,9 @@ void LibraryItem::setThumbnail(const QString &thumbnail)
 
 QString LibraryItem::fanart() const
 {
-    if(Kodi::instance()->imageCache()->contains(m_fanart, 1)) {
-        return Kodi::instance()->imageCache()->cachedFile(m_fanart, 1);
+    QString cachedFile;
+    if(Kodi::instance()->imageCache()->contains(m_fanart, 1, cachedFile)) {
+        return cachedFile;
     }
     int id = Kodi::instance()->imageCache()->fetch(m_fanart, const_cast<LibraryItem*>(this), "imageFetched", QSize(1000, 1000), 1);
     m_imageFetchJobs.insert(id, ImageTypeFanart);


### PR DESCRIPTION
Optimizes the processing of image downloads in multiple ways. Some are probably micro-optimizations.

- [x] Download the images in parallel
- [x] Track jobs based on image name + cache id, instead of searching them over and over
- [x] Include callbacks in the job, so there aren't multiple jobs for the same image
- [x] Generate cached filename only once, instead of multiple times for contains, loading, saving, ...
- [x] Check only for directory existence when the cached state has to be read from the FS
- [x] Prepare image download in parallel (will depend on KodiConnection implementation, but ImageCache doesn't need to queue manually)