### PR TITLE
lib: set parent on Playlist

### DIFF
--- a/libkodimote/kodimodel.cpp
+++ b/libkodimote/kodimodel.cpp
@@ -36,6 +36,17 @@ KodiModel::KodiModel(KodiModel *parent) :
 #endif
 }
 
+KodiModel::KodiModel(QObject *parent) :
+    QAbstractItemModel(parent),
+    m_parentModel(0),
+    m_busy(true),
+    m_ignoreArticle(false)
+{
+#ifndef QT5_BUILD
+    setRoleNames(roleNames());
+#endif
+}
+
 KodiModel::~KodiModel()
 {
     qDebug() << "deleting model";

--- a/libkodimote/kodimodel.h
+++ b/libkodimote/kodimodel.h
@@ -99,7 +99,8 @@ public:
         ItemIdRecentlyPlayed = -3
     };
 
-    explicit KodiModel(KodiModel *parent = 0);
+    explicit KodiModel(KodiModel *parent);
+    explicit KodiModel(QObject *parent = 0);
     virtual ~KodiModel();
     Q_INVOKABLE KodiModel *parentModel() const;
 

--- a/libkodimote/playlist.cpp
+++ b/libkodimote/playlist.cpp
@@ -25,6 +25,7 @@
 #include "kodebug.h"
 
 Playlist::Playlist(Player *parent) :
+    KodiModel(parent),
     m_currentItem(-1),
     m_player(parent)
 {


### PR DESCRIPTION
Not setting a parent leads to QML deleting in whenever it wants. Which
in turn could (would) lead to pretty random crashes.