### PR TITLE
#10 Improve reconnecting

### DIFF
--- a/apps/sailfish/qml/main.qml
+++ b/apps/sailfish/qml/main.qml
@@ -22,12 +22,16 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 import "pages"
 import "components"
+import "cover"
 
 ApplicationWindow
 {
     id: appWindow
 
-    cover: Qt.resolvedUrl("cover/CoverPage.qml")
+    cover: CoverPage {
+        id: cover
+    }
+
     initialPage: mainPageComponent
     bottomMargin: dockedControls.visibleSize
 
@@ -48,6 +52,13 @@ ApplicationWindow
 
     Keys.onVolumeUpPressed: {
         kodi.volumeUp();
+    }
+
+    Binding {
+        target: kodi
+        property: "active"
+        //!== Inactive to try to minimize all the switches when maximizing and minimizing the app
+        value: Qt.application.active || cover.status !== Cover.Inactive
     }
 
     function showAuthenticate(hostname) {

--- a/apps/sailfish/qml/pages/MainPage.qml
+++ b/apps/sailfish/qml/pages/MainPage.qml
@@ -39,7 +39,7 @@ Page {
     ]
 
     onConnectedChanged: {
-        pageStack.pop(mainPage);
+        pageStack.pop(mainPage, PageStackAction.Immediate);
         populateMainMenu();
         if (connected) {
             pageStack.pushAttached("KodiPage.qml");
@@ -351,6 +351,5 @@ Page {
     Connections {
         target: kodi
         onPvrAvailableChanged: populateMainMenu();
-        onConnectingChanged: pageStack.pop(mainPage, PageStackAction.Immediate);
     }
 }

--- a/libkodimote/kodi.cpp
+++ b/libkodimote/kodi.cpp
@@ -267,6 +267,17 @@ void Kodi::setAuthCredentials(const QString &username, const QString &password)
     KodiConnection::setAuthCredentials(username, password);
 }
 
+bool Kodi::active() const
+{
+    return KodiConnection::active();
+}
+
+void Kodi::setActive(bool active)
+{
+    KodiConnection::setActive(active);
+    emit activeChanged(active);
+}
+
 QString Kodi::connectionError()
 {
     return KodiConnection::connectionError();

--- a/libkodimote/kodi.h
+++ b/libkodimote/kodi.h
@@ -53,6 +53,7 @@ class Kodi : public QObject
 
     Q_PROPERTY(bool connecting READ connecting NOTIFY connectingChanged)
     Q_PROPERTY(bool connected READ connected NOTIFY connectedChanged)
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
     Q_PROPERTY(QString connectionError READ connectionError NOTIFY connectedChanged)
     Q_PROPERTY(KodiHost* connectedHost READ connectedHost NOTIFY connectedChanged)
     Q_PROPERTY(QString connectedHostName READ connectedHostName NOTIFY connectedChanged)
@@ -106,6 +107,9 @@ public:
     Q_INVOKABLE KodiHostModel* hostModel();
     Q_INVOKABLE void setAuthCredentials(const QString &username, const QString &password);
 
+    bool active() const;
+    void setActive(bool active);
+
     QString state();
 
     QString vfsPath();
@@ -148,6 +152,7 @@ public slots:
 signals:
     void connectingChanged();
     void connectedChanged(bool connected);
+    void activeChanged(bool connect);
     void authenticationRequired(const QString &hostname, const QString &address);
     void activePlayerChanged();
     void volumeChanged(int volume);

--- a/libkodimote/kodiconnection.cpp
+++ b/libkodimote/kodiconnection.cpp
@@ -168,6 +168,8 @@ void KodiConnectionPrivate::connect(KodiHost *host)
 
     // Stop the reconnect timer in case someone else triggers the connect
     m_reconnectTimer.stop();
+
+    m_connecting = true;
     closeConnection(false);
 
     // Don't automatically reconnect when device is offline and no host provided
@@ -177,8 +179,7 @@ void KodiConnectionPrivate::connect(KodiHost *host)
         return;
     }
 
-    qDebug() << "connecting";
-    m_connecting = true;
+    koDebug(XDAREA_CONNECTION) << "Start connecting to host";
 
     QNetworkConfiguration networkConfig = m_connManager->defaultConfiguration();
     m_networkSession = new QNetworkSession(networkConfig, this);

--- a/libkodimote/kodiconnection.h
+++ b/libkodimote/kodiconnection.h
@@ -40,6 +40,9 @@ void setAuthCredentials(const QString &username, const QString &password);
 bool connected();
 QString connectionError();
 
+bool active();
+void setActive(bool active);
+
 int sendCommand(const QString &command, const QVariant &params = QVariant());
 int sendCommand(const QString &command, const QVariant &params, QObject *callbackReceiver, const QString &callbackMember);
 

--- a/libkodimote/kodiconnection_p.h
+++ b/libkodimote/kodiconnection_p.h
@@ -88,6 +88,9 @@ public:
     void disconnectFromHost();
     void setAuthCredentials(const QString &username, const QString &password);
 
+    bool active() const;
+    void setActive(bool active);
+
     int sendCommand(const QString &command, const QVariant &parms = QVariant());
     int sendCommand(const QString &command, const QVariant &params, QObject *callbackReceiver, const QString &callbackMember);
 
@@ -134,7 +137,7 @@ private:
 
     void sendNextCommand();
     void handleData(const QString &data);
-    void closeConnection();
+    void closeConnection(bool reconnect = true);
 
     KodiHost *m_host;
 
@@ -146,6 +149,7 @@ private:
     QMap<int, Callback> m_callbacks;
     QNetworkConfigurationManager *m_connManager;
     QNetworkSession *m_networkSession;
+    bool m_active;
 
     QList<KodiDownload*> m_downloadQueue;
     QMap<QNetworkReply*, KodiDownload*> m_activeDownloadsMap;

--- a/libkodimote/kodiconnection_p.h
+++ b/libkodimote/kodiconnection_p.h
@@ -47,10 +47,10 @@ public:
     Command(int id = -1, const QString &command = QString(), const QVariant &params = QVariant(), const QString &raw = QString()):
         m_id(id), m_command(command), m_params(params), m_raw(raw) {}
 
-    int id() {return m_id;}
-    QString command() {return m_command;}
-    QVariant params() {return m_params;}
-    QString raw() {return m_raw; }
+    int id() const {return m_id;}
+    QString command() const {return m_command;}
+    QVariant params() const {return m_params;}
+    QString raw() const {return m_raw; }
 
 private:
 
@@ -112,6 +112,9 @@ private slots:
     void sessionLost();
     void versionReceived(const QVariantMap &rsp);
 
+    void pingElapsed();
+    void pingReplyReceived(const QVariantMap &rsp);
+
     void replyReceived();
     void authenticationRequired(QNetworkReply *reply, QAuthenticator *authenticator);
 
@@ -134,10 +137,12 @@ private:
     Command m_currentPendingCommand;
     QTimer m_timeoutTimer;
     QTimer m_reconnectTimer;
+    QTimer m_pingTimeoutTimer;
 
     void sendNextCommand();
     void handleData(const QString &data);
     void closeConnection(bool reconnect = true);
+    QByteArray buildJsonPayload(const Command &command);
 
     KodiHost *m_host;
 

--- a/libkodimote/kodiconnection_p.h
+++ b/libkodimote/kodiconnection_p.h
@@ -150,6 +150,7 @@ private:
     QNetworkReply *m_lastAuthRequest;
     bool m_connecting;
     bool m_connected;
+    bool m_disconnecting;
     QString m_connectionError;
     QMap<int, Callback> m_callbacks;
     QNetworkConfigurationManager *m_connManager;


### PR DESCRIPTION
Implements #10 on top of #2.

- [x] Implement logic to only reconnect when active/app wants to reconnect
- [x] Run reconnect timer when Kodi disconnects
- [x] Hook into Sailfish active
- [x] Hook into Sailfish cover (also reconnect when only visible on cover, for accurate connection status)
- [ ] Hook into Ubuntu active
- [x] Send ping over TCP connection when keep alive is set to true to check if connection is still working