### PR TITLE
Add support for browsing music and video addon sources

### DIFF
--- a/libkodimote/addonsource.cpp
+++ b/libkodimote/addonsource.cpp
@@ -1,0 +1,29 @@
+#include "addonsource.h"
+#include "libraryitem.h"
+
+AddonSource::AddonSource(const QString &title, const QString &mediaType, const QString &dir, KodiModel *parent) :
+    Files(mediaType, dir, parent),
+    m_title(title)
+{
+    m_sort = false;
+}
+
+QString AddonSource::title() const
+{
+    return m_title;
+}
+
+KodiModel *AddonSource::enterItem(int index)
+{
+    LibraryItem *item = static_cast<LibraryItem*>(m_list.at(index));
+    if(item->fileType() == "directory") {
+        return new AddonSource(item->title(), m_mediaType, item->fileName(), this);
+    }
+    qDebug() << "cannot enter item of type file";
+    return 0;
+}
+
+QString AddonSource::parseTitle(const QString &title) const
+{
+    return QString(title).replace(QRegExp("\\[/?\\w\\]"), "");
+}

--- a/libkodimote/addonsource.cpp
+++ b/libkodimote/addonsource.cpp
@@ -27,3 +27,8 @@ QString AddonSource::parseTitle(const QString &title) const
 {
     return QString(title).replace(QRegExp("\\[/?\\w\\]"), "");
 }
+
+bool AddonSource::filterFile(const QVariantMap &item) const
+{
+    return !item.value("file").toString().startsWith("addons://more/");
+}

--- a/libkodimote/addonsource.h
+++ b/libkodimote/addonsource.h
@@ -1,0 +1,22 @@
+#ifndef ADDONSOURCE_H
+#define ADDONSOURCE_H
+
+#include "files.h"
+
+class AddonSource : public Files
+{
+    Q_OBJECT
+public:
+    explicit AddonSource(const QString &title, const QString &mediaType, const QString &dir, KodiModel *parent = 0);
+
+    QString title() const;
+    KodiModel *enterItem(int index);
+
+protected:
+    QString parseTitle(const QString &title) const;
+
+private:
+    QString m_title;
+};
+
+#endif // ADDONSOURCE_H

--- a/libkodimote/addonsource.h
+++ b/libkodimote/addonsource.h
@@ -14,6 +14,7 @@ public:
 
 protected:
     QString parseTitle(const QString &title) const;
+    bool filterFile(const QVariantMap &item) const;
 
 private:
     QString m_title;

--- a/libkodimote/audiolibrary.cpp
+++ b/libkodimote/audiolibrary.cpp
@@ -26,6 +26,7 @@
 #include "recentitems.h"
 #include "kodiconnection.h"
 #include "libraryitem.h"
+#include "addonsource.h"
 
 AudioLibrary::AudioLibrary() :
     KodiLibrary(0)
@@ -60,6 +61,11 @@ AudioLibrary::AudioLibrary() :
     item->setFileType("directory");
     item->setPlayable(false);
     m_list.append(item);
+
+    item = new LibraryItem(tr("Music Add-ons"), QString(), this);
+    item->setFileType("directory");
+    item->setPlayable(false);
+    m_list.append(item);
 }
 
 KodiModel *AudioLibrary::enterItem(int index)
@@ -77,6 +83,8 @@ KodiModel *AudioLibrary::enterItem(int index)
         return new RecentItems(RecentItems::ModeAudio, RecentItems::RecentlyAdded, this);
     case 5:
         return new RecentItems(RecentItems::ModeAudio, RecentItems::RecentlyPlayed, this);
+    case 6:
+        return new AddonSource(tr("Music Add-ons"), "music", "addons://sources/audio", this);
     }
     return 0;
 }

--- a/libkodimote/files.cpp
+++ b/libkodimote/files.cpp
@@ -70,6 +70,10 @@ void Files::listReceived(const QVariantMap &rsp)
     QVariantList responseList = rsp.value("result").toMap().value("files").toList();
     foreach(const QVariant &itemVariant, responseList) {
         QVariantMap itemMap = itemVariant.toMap();
+        if (!filterFile(itemMap)) {
+            continue;
+        }
+
         LibraryItem *item = new LibraryItem(this);
         item->setTitle(parseTitle(itemMap.value("label").toString()));
         item->setFileType(itemMap.value("filetype").toString());
@@ -188,4 +192,9 @@ void Files::download(int index, const QString &path)
 QString Files::parseTitle(const QString &title) const
 {
     return title;
+}
+
+bool Files::filterFile(const QVariantMap &) const
+{
+    return true;
 }

--- a/libkodimote/files.cpp
+++ b/libkodimote/files.cpp
@@ -33,7 +33,8 @@
 Files::Files(const QString &mediaType, const QString &dir, KodiModel *parent):
     KodiLibrary(parent),
     m_mediaType(mediaType),
-    m_dir(dir)
+    m_dir(dir),
+    m_sort(true)
 {
 }
 
@@ -50,11 +51,13 @@ void Files::refresh()
     }
     params.insert("properties", properties);
 
-    QVariantMap sort;
-    sort.insert("method", "label");
-    sort.insert("order", "ascending");
-    sort.insert("ignorearticle", ignoreArticle());
-    params.insert("sort", sort);
+    if (m_sort) {
+        QVariantMap sort;
+        sort.insert("method", "label");
+        sort.insert("order", "ascending");
+        sort.insert("ignorearticle", ignoreArticle());
+        params.insert("sort", sort);
+    }
 
     KodiConnection::sendCommand("Files.GetDirectory", params, this, "listReceived");
 }
@@ -68,7 +71,7 @@ void Files::listReceived(const QVariantMap &rsp)
     foreach(const QVariant &itemVariant, responseList) {
         QVariantMap itemMap = itemVariant.toMap();
         LibraryItem *item = new LibraryItem(this);
-        item->setTitle(itemMap.value("label").toString());
+        item->setTitle(parseTitle(itemMap.value("label").toString()));
         item->setFileType(itemMap.value("filetype").toString());
         item->setFileName(itemMap.value("file").toString());
         if(m_mediaType == "pictures") {
@@ -180,4 +183,9 @@ void Files::download(int index, const QString &path)
     download->setLabel(item->title());
 
     startDownload(index, download);
+}
+
+QString Files::parseTitle(const QString &title) const
+{
+    return title;
 }

--- a/libkodimote/files.h
+++ b/libkodimote/files.h
@@ -42,9 +42,12 @@ public slots:
 private slots:
     void listReceived(const QVariantMap &rsp);
 
-private:
+protected:
     QString m_mediaType;
     QString m_dir;
+    bool m_sort;
+
+    virtual QString parseTitle(const QString &title) const;
 };
 
 #endif // FILES_H

--- a/libkodimote/files.h
+++ b/libkodimote/files.h
@@ -48,6 +48,7 @@ protected:
     bool m_sort;
 
     virtual QString parseTitle(const QString &title) const;
+    virtual bool filterFile(const QVariantMap &item) const;
 };
 
 #endif // FILES_H

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -71,7 +71,8 @@ SOURCES +=  kodi.cpp \
 	    channelbroadcasts.cpp \
 	    recordings.cpp \
 	    pvrmenu.cpp \
-            kodihost.cpp
+            kodihost.cpp \
+            addonsource.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -125,4 +126,5 @@ HEADERS += libkodimote_global.h \
 	   channelbroadcasts.h \
 	   recordings.h \
 	   pvrmenu.h \
-           kodihost.h
+           kodihost.h \
+           addonsource.h

--- a/libkodimote/videolibrary.cpp
+++ b/libkodimote/videolibrary.cpp
@@ -25,6 +25,7 @@
 #include "recentitems.h"
 #include "kodiconnection.h"
 #include "libraryitem.h"
+#include "addonsource.h"
 
 VideoLibrary::VideoLibrary(KodiModel *parent) :
     KodiLibrary(parent)
@@ -49,6 +50,11 @@ VideoLibrary::VideoLibrary(KodiModel *parent) :
     item->setFileType("directory");
     item->setPlayable(false);
     m_list.append(item);
+
+    item = new LibraryItem(tr("Video Add-ons"), QString(), this);
+    item->setFileType("directory");
+    item->setPlayable(false);
+    m_list.append(item);
 }
 
 KodiModel *VideoLibrary::enterItem(int index)
@@ -62,6 +68,8 @@ KodiModel *VideoLibrary::enterItem(int index)
         return new MusicVideos(false, this);
     case 3:
         return new RecentItems(RecentItems::ModeVideo, RecentItems::RecentlyAdded, this);
+    case 4:
+        return new AddonSource(tr("Video Add-ons"), "video", "addons://sources/video", this);
     }
     return 0;
 }


### PR DESCRIPTION
This adds support for browsing addon sources as described in #12.

There is however one issue (in the Sailfish app) which most prominently shows by these changes. When you open a directory which starts showing an input dialog in Kodi we'll immediately show an input dialog in the app. But Sailfish doesn't like this, as opening the dialog means pushing a page on the stack, but there is already a page transition in progress (to open the directory), which means Sailfish completely ignores the push of the dialog. So this should be fixed (in the sailfish app) to have a proper implementation.