### PR TITLE
move files into the submenu instead of long-pressing on music or videos

### DIFF
--- a/apps/sailfish/qml/pages/MainPage.qml
+++ b/apps/sailfish/qml/pages/MainPage.qml
@@ -70,8 +70,9 @@ Page {
         if (menuModel.mode === "library") {
             newModel = kodi[menuModel.libraryTarget]();
         } else {
-                newModel = kodi.shares(menuModel.target);
+            newModel = kodi.shares(menuModel.target);
         }
+
 
         console.log("setting model: " + newModel);
         var browser = pageStack.push("BrowserPage.qml", {model: newModel});
@@ -174,21 +175,6 @@ Page {
                     font.weight: Font.Bold
                     font.pixelSize: Theme.fontSizeLarge
                 }
-
-                Label {
-                    id: subText
-                    text: {
-                        if (mode === "library") {
-                            return qsTr("Library");
-                        } else if (mode == "files") {
-                            return qsTr("Files");
-                        } else {
-                            return ""
-                        }
-                    }
-                    visible: libraryTarget && sharesTarget
-                    color: Theme.secondaryColor
-                }
             }
 
             onPressed: listView.currentSelected = index;
@@ -203,22 +189,6 @@ Page {
                 ContextMenu {
                     id: contextMenu
 
-                    MenuItem {
-                        visible: mode !== "files" && mode !== "single"
-                        text: qsTr("Show files")
-                        onClicked: {
-                            listView.model.get(listView.currentSelected).mode = "files";
-                            settings[target + "ShowsFiles"] = true;
-                        }
-                    }
-                    MenuItem {
-                        visible: mode !== "library" && mode !== "single"
-                        text: qsTr("Show library")
-                        onClicked: {
-                            listView.model.get(listView.currentSelected).mode = "library";
-                            settings[target + "ShowsFiles"] = false;
-                        }
-                    }
                     MenuItem {
                         text: qsTr("Rescan library")
                         onClicked: {
@@ -264,7 +234,6 @@ Page {
             mode: "library"
             target: "music"
             libraryTarget: "audioLibrary"
-            sharesTarget: "music"
             hasMenu: true
         }
         ListElement {
@@ -273,7 +242,6 @@ Page {
             mode: "library"
             target: "video"
             libraryTarget: "videoLibrary"
-            sharesTarget: "video"
             hasMenu: true
         }
         ListElement {
@@ -330,13 +298,6 @@ Page {
         }
         if (settings.pvrEnabled && kodi.pvrAvailable) {
             mainMenuModel.append(mainMenuModelTemplate.get(3));
-        }
-
-        if(settings.musicShowsFiles) {
-           mainMenuModel.setProperty(0, "mode", "files");
-        }
-        if(settings.videoShowsFiles) {
-            mainMenuModel.setProperty(1, "mode", "files");
         }
     }
 

--- a/apps/ubuntu/qml/MainPage.qml
+++ b/apps/ubuntu/qml/MainPage.qml
@@ -33,12 +33,6 @@ KodiPage {
     property int spacing
 
     Component.onCompleted: {
-        if(settings.musicShowsFiles) {
-           mainMenuModel.setProperty(0, "mode", "files");
-        }
-        if(settings.videoShowsFiles) {
-            mainMenuModel.setProperty(1, "mode", "files");
-        }
         populateMainMenu();
     }
 
@@ -48,25 +42,21 @@ KodiPage {
         ListElement {
             icon: "icon-m-content-audio"
             subtitle: ""
-            mode: "library"
             target: "music"
         }
         ListElement {
             icon: "icon-m-content-videos"
             subtitle: ""
-            mode: "library"
             target: "videos"
         }
         ListElement {
             icon: "icon-m-content-image"
             subtitle: ""
-            mode: "files"
             target: "pictures"
         }
         ListElement {
             icon: "icon-m-content-image"
             subtitle: ""
-            mode: "library"
             target: "tv"
         }
     }
@@ -173,38 +163,17 @@ KodiPage {
                 "
             }
 
-            Row {
-                id: textRow
-                anchors.fill: parent
-                height: 150
-                spacing: units.gu(4)
-                anchors.margins: units.gu(4)
-
-
-                Image {
-                    id: toolIcon
-                    anchors.verticalCenter: parent.verticalCenter
-//                    source: "image://theme/" + icon + (theme.inverted ? "-inverse" : "")
+            Label {
+                anchors {
+                    left: parent.left
+                    leftMargin: units.gu(4)
+                    verticalCenter: parent.verticalCenter
                 }
-
-                Column {
-                    anchors.verticalCenter: parent.verticalCenter
-
-                    Label {
-                        id: mainText
-                        text: listView.model.title(index)
-                        font.weight: Font.Bold
-                        fontSize: "large"
-                        color: "white"
-                    }
-
-                    Label {
-                        id: subText
-                        text: mode === "library" ? qsTr("Library") : qsTr("Files")
-                        visible: target == "music" || target == "videos"
-                        color: "white"
-                    }
-                }
+                id: mainText
+                text: listView.model.title(index)
+                font.weight: Font.Bold
+                fontSize: "large"
+                color: "white"
             }
 
             MouseArea {
@@ -219,22 +188,7 @@ KodiPage {
                         var popover = openLongTapMenu(listItem, index)
                         popover.selected.connect(function(actionId) {
                             switch (actionId) {
-                            case 0:
-                                mainMenuModel.get(index).mode = "files"
-                                if (mainMenuModel.get(index).target === "music") {
-                                    settings.musicShowsFiles = true;
-                                } else if (mainMenuModel.get(index).target === "videos") {
-                                    settings.videosShowsFiles = true;
-                                }
-                                break;
-                            case 1:
-                                mainMenuModel.get(index).mode = "library"
-                                if (mainMenuModel.get(index).target === "music") {
-                                    settings.musicShowsFiles = false;
-                                } else if (mainMenuModel.get(index).target === "videos") {
-                                    settings.videosShowsFiles = false;
-                                }
-                            case 2:
+                            case "rescan":
                                 var lib = kodi.audioLibrary();
                                 if (index == 0) {
                                     lib = kodi.audioLibrary();
@@ -244,7 +198,7 @@ KodiPage {
                                 lib.scanForContent();
                                 lib.exit();
                                 break;
-                            case 3:
+                            case "clean":
                                 var lib = kodi.audioLibrary();
                                 if (index == 0) {
                                     lib = kodi.audioLibrary();
@@ -266,18 +220,10 @@ KodiPage {
                     if (component.status === Component.Ready) {
                         switch(mainMenuModel.get(index).target) {
                         case "music":
-                            if(mode === "library") {
-                                newModel = kodi.audioLibrary();
-                            } else {
-                                newModel = kodi.shares("music");
-                            }
+                            newModel = kodi.audioLibrary();
                             break
                         case "videos":
-                            if(mode === "library") {
-                                newModel = kodi.videoLibrary();
-                            } else {
-                                newModel = kodi.shares("video");
-                            }
+                            newModel = kodi.videoLibrary();
                             break;
                         case "pictures":
                             newModel = kodi.shares("pictures");
@@ -305,15 +251,9 @@ KodiPage {
     function openLongTapMenu(parent, index) {
         print("opening longtap for index", index)
         longTapModel.clear()
-        if (mainMenuModel.get(index).mode == "library") {
-            longTapModel.append({modelData: qsTr("Show files"), actionId: 0})
-        }
-        if (mainMenuModel.get(index).mode == "files") {
-            longTapModel.append({modelData: qsTr("Show library"), actionId: 1})
-        }
         if (index < 3) {
-            longTapModel.append({modelData: qsTr("Rescan library"), actionId: 2})
-            longTapModel.append({modelData: qsTr("Clean library"), actionId: 3})
+            longTapModel.append({modelData: qsTr("Rescan library"), actionId: "rescan"})
+            longTapModel.append({modelData: qsTr("Clean library"), actionId: "clean"})
         }
         return PopupUtils.open(longTapMenu, parent, {model: longTapModel})
     }

--- a/libkodimote/audiolibrary.cpp
+++ b/libkodimote/audiolibrary.cpp
@@ -27,6 +27,7 @@
 #include "kodiconnection.h"
 #include "libraryitem.h"
 #include "addonsource.h"
+#include "shares.h"
 
 AudioLibrary::AudioLibrary() :
     KodiLibrary(0)
@@ -66,6 +67,11 @@ AudioLibrary::AudioLibrary() :
     item->setFileType("directory");
     item->setPlayable(false);
     m_list.append(item);
+
+    item = new LibraryItem(tr("Files"), QString(), this);
+    item->setFileType("directory");
+    item->setPlayable(false);
+    m_list.append(item);
 }
 
 KodiModel *AudioLibrary::enterItem(int index)
@@ -85,6 +91,8 @@ KodiModel *AudioLibrary::enterItem(int index)
         return new RecentItems(RecentItems::ModeAudio, RecentItems::RecentlyPlayed, this);
     case 6:
         return new AddonSource(tr("Music Add-ons"), "music", "addons://sources/audio", this);
+    case 7:
+        return new Shares("music");
     }
     return 0;
 }

--- a/libkodimote/settings.cpp
+++ b/libkodimote/settings.cpp
@@ -147,32 +147,6 @@ void Settings::setKeepDisplayLit(bool keepLit)
     emit keepDisplayLitChanged();
 }
 
-bool Settings::musicShowsFiles() const
-{
-    QSettings settings;
-    return settings.value("MusicShowsFiles", false).toBool();
-}
-
-void Settings::setMusicShowsFiles(bool showFiles)
-{
-    QSettings settings;
-    settings.setValue("MusicShowsFiles", showFiles);
-    emit musicShowsFilesChanged();
-}
-
-bool Settings::videoShowsFiles() const
-{
-    QSettings settings;
-    return settings.value("VideoShowsFiles", false).toBool();
-}
-
-void Settings::setVideoShowsFiles(bool showFiles)
-{
-    QSettings settings;
-    settings.setValue("VideoShowsFiles", showFiles);
-    emit videoShowsFilesChanged();
-}
-
 bool Settings::musicEnabled() const
 {
     QSettings settings;

--- a/libkodimote/settings.h
+++ b/libkodimote/settings.h
@@ -36,8 +36,6 @@ class Settings : public QObject
     Q_PROPERTY(bool pauseMusicOnCall READ pauseMusicOnCall WRITE setPauseMusicOnCall NOTIFY pauseMusicOnCallChanged)
     Q_PROPERTY(bool keepDisplayLit READ keepDisplayLit WRITE setKeepDisplayLit NOTIFY keepDisplayLitChanged)
     Q_PROPERTY(bool showCallNotifications READ showCallNotifications WRITE setShowCallNotifications NOTIFY showCallNotificationsChanged)
-    Q_PROPERTY(bool musicShowsFiles READ musicShowsFiles WRITE setMusicShowsFiles NOTIFY musicShowsFilesChanged)
-    Q_PROPERTY(bool videoShowsFiles READ videoShowsFiles WRITE setVideoShowsFiles NOTIFY videoShowsFilesChanged)
     Q_PROPERTY(bool musicEnabled READ musicEnabled WRITE setMusicEnabled NOTIFY musicEnabledChanged)
     Q_PROPERTY(bool videosEnabled READ videosEnabled WRITE setVideosEnabled NOTIFY videosEnabledChanged)
     Q_PROPERTY(bool picturesEnabled READ picturesEnabled WRITE setPicturesEnabled NOTIFY picturesEnabledChanged)
@@ -74,12 +72,6 @@ public:
     bool keepDisplayLit() const;
     void setKeepDisplayLit(bool keepLit);
 
-    bool musicShowsFiles() const;
-    void setMusicShowsFiles(bool showFiles);
-
-    bool videoShowsFiles() const;
-    void setVideoShowsFiles(bool showFiles);
-
     bool musicEnabled() const;
     void setMusicEnabled(bool enabled);
 
@@ -107,8 +99,6 @@ signals:
     void pauseMusicOnCallChanged();
     void keepDisplayLitChanged();
     void showCallNotificationsChanged();
-    void musicShowsFilesChanged();
-    void videoShowsFilesChanged();
     void musicEnabledChanged();
     void videosEnabledChanged();
     void picturesEnabledChanged();

--- a/libkodimote/videolibrary.cpp
+++ b/libkodimote/videolibrary.cpp
@@ -26,6 +26,7 @@
 #include "kodiconnection.h"
 #include "libraryitem.h"
 #include "addonsource.h"
+#include "shares.h"
 
 VideoLibrary::VideoLibrary(KodiModel *parent) :
     KodiLibrary(parent)
@@ -55,6 +56,11 @@ VideoLibrary::VideoLibrary(KodiModel *parent) :
     item->setFileType("directory");
     item->setPlayable(false);
     m_list.append(item);
+
+    item = new LibraryItem(tr("Files"), QString(), this);
+    item->setFileType("directory");
+    item->setPlayable(false);
+    m_list.append(item);
 }
 
 KodiModel *VideoLibrary::enterItem(int index)
@@ -70,6 +76,8 @@ KodiModel *VideoLibrary::enterItem(int index)
         return new RecentItems(RecentItems::ModeVideo, RecentItems::RecentlyAdded, this);
     case 4:
         return new AddonSource(tr("Video Add-ons"), "video", "addons://sources/video", this);
+    case 5:
+        return new Shares("video");
     }
     return 0;
 }


### PR DESCRIPTION
Only Ubuntu ui updated.

The Sailfish ui needs to be updated:
* drop subtitle (files/videos) from Music and Video main menu entries
* drop library/files toggle from longpress menu

I looked into it but then I saw you're doing it a bit different than the ubuntu UI so I didn't want to do changes blindly as I currently don't have a working sailfish dev env.

@RobertMe: can you do those changes?