### PR TITLE
add an intro to explain how the gesture pad works

### DIFF
--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -26,14 +26,23 @@ import Kodi 1.0
 Item {
     id: root
 
-    function teaseArrows() {
-        teaseTimer.start()
-    }
     Timer {
         id: teaseTimer
         interval: 1000
+        running: settings.introStep < Settings.IntroStepDone
+        repeat: true
         onTriggered: {
-            animateAll();
+            if (settings.introStep == Settings.IntroStepLeftRight || settings.introStep == Settings.IntroStepClick) {
+                leftArrows.item.animate()
+                rightArrows.item.animate();
+            }
+            if (settings.introStep == Settings.IntroStepUpDown || settings.introStep == Settings.IntroStepClick) {
+                upArrows.item.animate()
+                downArrows.item.animate();
+            }
+            if (settings.introStep == Settings.IntroStepScroll) {
+                downArrows.item.animate();
+            }
         }
     }
 
@@ -212,11 +221,23 @@ Item {
             // Lets use newSpeed for changing and fetch it when appropriate
             property int newSpeed: -1
 
+            property int introScrollCount: 0
             onTriggered: {
                 if(newSpeed !== -1) {
                     speed = newSpeed;
                     newSpeed = -1;
                 }
+                if (settings.introStep < Settings.IntroStepDone) {
+                    if (settings.introStep == Settings.IntroStepScroll) {
+                        rumbleEffect.start(1);
+                        introScrollCount++;
+                        if (introScrollCount >= 10) {
+                            settings.introStep++;
+                        }
+                    }
+                    return;
+                }
+
                 mouseArea.doKeyPress();
             }
         }
@@ -230,6 +251,13 @@ Item {
             // Did we not move? => press enter
             if (dxAbs < maxClickDistance && dyAbs < maxClickDistance) {
                 print("pressing enter")
+                if (settings.introStep < Settings.IntroStepDone) {
+                    if (settings.introStep == Settings.IntroStepClick) {
+                        settings.introStep++;
+                    }
+                    return;
+                }
+
                 keys.select();
                 rumbleEffect.start(1);
                 animateAll();
@@ -249,6 +277,13 @@ Item {
             // Reason is that the thumb can easily produce large vertical deltas
             // just by touching the screen with more than the tip
             if (dxAbs > minSwipeDistance * 2 || dxAbs > dyAbs) {
+                if (settings.introStep < Settings.IntroStepDone) {
+                    if (settings.introStep == Settings.IntroStepLeftRight) {
+                        settings.introStep++;
+                    }
+                    return;
+                }
+
                 if (dx < 0) {
                     leftArrows.item.animate();
                     keys.left();
@@ -257,6 +292,12 @@ Item {
                     keys.right();
                 }
             } else {
+                if (settings.introStep < Settings.IntroStepDone) {
+                    if (settings.introStep == Settings.IntroStepUpDown) {
+                        settings.introStep++;
+                    }
+                    return;
+                }
                 if (dy < 0) {
                     upArrows.item.animate();
                     keys.up();

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -46,6 +46,7 @@ Item {
                 break;
             case Settings.IntroStepColors:
             case Settings.IntroStepClick:
+            case Settings.IntroStepExit:
                 animateAll();
                 break;
             }
@@ -261,6 +262,11 @@ Item {
                     if (settings.introStep == Settings.IntroStepClick || settings.introStep == Settings.IntroStepColors) {
                         settings.introStep++;
                     }
+                    // If the user just clicked here during the colors step, let's skip the exit step
+                    if (settings.introStep == Settings.IntroStepExit) {
+                        settings.introStep++;
+                    }
+
                     return;
                 }
 

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -32,16 +32,22 @@ Item {
         running: settings.introStep < Settings.IntroStepDone
         repeat: true
         onTriggered: {
-            if (settings.introStep == Settings.IntroStepLeftRight || settings.introStep == Settings.IntroStepClick) {
+            switch (settings.introStep) {
+            case Settings.IntroStepLeftRight:
                 leftArrows.item.animate()
                 rightArrows.item.animate();
-            }
-            if (settings.introStep == Settings.IntroStepUpDown || settings.introStep == Settings.IntroStepClick) {
+                break;
+            case Settings.IntroStepUpDown:
                 upArrows.item.animate()
                 downArrows.item.animate();
-            }
-            if (settings.introStep == Settings.IntroStepScroll) {
+                break;
+            case Settings.IntroStepScroll:
                 downArrows.item.animate();
+                break;
+            case Settings.IntroStepColors:
+            case Settings.IntroStepClick:
+                animateAll();
+                break;
             }
         }
     }
@@ -252,7 +258,7 @@ Item {
             if (dxAbs < maxClickDistance && dyAbs < maxClickDistance) {
                 print("pressing enter")
                 if (settings.introStep < Settings.IntroStepDone) {
-                    if (settings.introStep == Settings.IntroStepClick) {
+                    if (settings.introStep == Settings.IntroStepClick || settings.introStep == Settings.IntroStepColors) {
                         settings.introStep++;
                     }
                     return;

--- a/apps/ubuntu/qml/Keypad.qml
+++ b/apps/ubuntu/qml/Keypad.qml
@@ -35,10 +35,6 @@ KodiPage {
 
     property int spacing: units.gu(2)
 
-    function teaseArrows() {
-        gesturePad.teaseArrows();
-    }
-
     property QtObject keys: kodi.keys()
 
     Column {
@@ -56,6 +52,7 @@ KodiPage {
             color: Qt.rgba(0, 0, 0, 0.05)
 
             Label {
+                id: introLabel1
                 anchors.fill: parent
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
@@ -66,7 +63,7 @@ KodiPage {
                 text: {
                     switch (settings.introStep) {
                     case Settings.IntroStepLeftRight:
-                        return qsTr("To move left or right, swipe horizontally.");
+                        return qsTr("To move left or right, swipe horizontally anywhere on the pad.");
                     case Settings.IntroStepUpDown:
                         return qsTr("To move up or down, swipe vertically.");
                     case Settings.IntroStepScroll:
@@ -75,6 +72,8 @@ KodiPage {
                         return qsTr("To select an item, tap anywhere on the pad.");
                     case Settings.IntroStepColors:
                         return qsTr("Pro tip: The color buttons at the bottom simulate an infrared remote.")
+                    case Settings.IntroStepExit:
+                        return qsTr("Tap the pad to finish the tutorial.")
                     }
                     return ""
                 }
@@ -227,7 +226,7 @@ KodiPage {
                     }
                     return ""
                 }
-                opacity: (settings.introStep == Settings.IntroStepScroll || settings.introStep == Settings.IntroStepColors) ? 1 : 0
+                opacity: settings.introStep < Settings.IntroStepDone ? 1 : 0
                 Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
             }
 
@@ -265,8 +264,9 @@ KodiPage {
                     AbstractButton {
                         anchors.fill: parent; anchors.margins: -10;
                         onClicked: {
-                            if (settings.introStep == Settings.IntroStepColors) {
+                            if (settings.introStep < Settings.IntroStepDone) {
                                 introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("red")
+                                settings.introStep = Settings.IntroStepExit;
                             }
                             keys.red()
                         }
@@ -277,8 +277,9 @@ KodiPage {
                     AbstractButton {
                         anchors.fill: parent; anchors.margins: -10;
                         onClicked: {
-                            if (settings.introStep == Settings.IntroStepColors) {
+                            if (settings.introStep < Settings.IntroStepDone) {
                                 introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("green")
+                                settings.introStep = Settings.IntroStepExit;
                             }
                             keys.green()
                         }
@@ -289,8 +290,9 @@ KodiPage {
                     AbstractButton {
                         anchors.fill: parent; anchors.margins: -10;
                         onClicked: {
-                            if (settings.introStep == Settings.IntroStepColors) {
+                            if (settings.introStep < Settings.IntroStepDone) {
                                 introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("yellow")
+                                settings.introStep = Settings.IntroStepExit;
                             }
                             keys.yellow()
                         }
@@ -301,8 +303,9 @@ KodiPage {
                     AbstractButton {
                         anchors.fill: parent; anchors.margins: -10;
                         onClicked: {
-                            if (settings.introStep == Settings.IntroStepColors) {
+                            if (settings.introStep < Settings.IntroStepDone) {
                                 introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("blue")
+                                settings.introStep = Settings.IntroStepExit;
                             }
                             keys.blue()
                         }

--- a/apps/ubuntu/qml/Keypad.qml
+++ b/apps/ubuntu/qml/Keypad.qml
@@ -55,7 +55,32 @@ KodiPage {
             height: musicButton.height + root.spacing
             color: Qt.rgba(0, 0, 0, 0.05)
 
+            Label {
+                anchors.fill: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.WordWrap
+                opacity: settings.introStep < Settings.IntroStepDone ? 1 : 0
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
+                color: "white"
+                text: {
+                    switch (settings.introStep) {
+                    case Settings.IntroStepLeftRight:
+                        return qsTr("To move left or right, swipe horizontally.");
+                    case Settings.IntroStepUpDown:
+                        return qsTr("To move up or down, swipe vertically.");
+                    case Settings.IntroStepScroll:
+                        return qsTr("To scroll through lists, press and keep holding while dragging.");
+                    case Settings.IntroStepClick:
+                        return qsTr("To select an item, tap anywhere on the pad.");
+                    }
+                    return ""
+                }
+            }
+
             Row {
+                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
                 id: jumpPointRow
                 anchors {
                     left: parent.left
@@ -101,6 +126,9 @@ KodiPage {
                 id: backButton
                 anchors { left: parent.left; top: parent.top; margins: units.gu(1.5) }
                 source: "image://theme/back"
+                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
+
                 AbstractButton {
                     width: parent.width * 2
                     height: parent.height * 1.2
@@ -116,6 +144,8 @@ KodiPage {
             MediaControlButton {
                 anchors { right: parent.right; top: parent.top; margins: units.gu(1.5) }
                 source: usePictureControls ? "image://theme/add" : "image://theme/view-fullscreen"
+                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
                 AbstractButton {
                     width: parent.width * 2
                     height: parent.height * 1.2
@@ -133,6 +163,8 @@ KodiPage {
             MediaControlButton {
                 anchors { left: parent.left; bottom: parent.bottom; margins: units.gu(1.5) }
                 source: usePictureControls ? "image://theme/reload" : "image://theme/info"
+                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
                 AbstractButton {
                     width: parent.width * 2
                     height: parent.height * 1.2
@@ -150,6 +182,8 @@ KodiPage {
             MediaControlButton {
                 anchors { right: parent.right; bottom: parent.bottom; margins: units.gu(1.5) }
                 source: usePictureControls ? "image://theme/remove" : "image://theme/navigation-menu"
+                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
                 AbstractButton {
                     width: parent.width * 2
                     height: parent.height * 1.2
@@ -175,6 +209,17 @@ KodiPage {
             height: controlButtons.height + root.spacing
             color: Qt.rgba(0, 0, 0, 0.05)
 
+            Label {
+                anchors.fill: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                color: "white"
+                wrapMode: Text.WordWrap
+                text: settings.introStep == Settings.IntroStepScroll ? qsTr("The further you move, the faster you scroll.") : ""
+                opacity: settings.introStep == Settings.IntroStepScroll ? 1 : 0
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
+            }
+
             PlayerControls {
                 id: controlButtons
                 anchors {
@@ -183,6 +228,8 @@ KodiPage {
                     margins: root.spacing / 2
                     verticalCenter: parent.verticalCenter
                 }
+                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
 
                 player: usePictureControls ? root.picturePlayer : root.player
             }
@@ -199,6 +246,8 @@ KodiPage {
                 anchors.centerIn: parent
                 height: controlButtons.height
                 spacing: parent.width / 8
+                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
                 UbuntuShape { height: units.gu(2); width: parent.spacing; color: "red"; anchors.verticalCenter: parent.verticalCenter;
                     AbstractButton { anchors.fill: parent; anchors.margins: -10; onClicked: { keys.red() } }
                 }
@@ -225,4 +274,8 @@ KodiPage {
             }
         }
     }
+
+//    GesturesIntro {
+//        id: gesturesIntro
+//    }
 }

--- a/apps/ubuntu/qml/Keypad.qml
+++ b/apps/ubuntu/qml/Keypad.qml
@@ -212,6 +212,7 @@ KodiPage {
             color: Qt.rgba(0, 0, 0, 0.05)
 
             Label {
+                id: introLabel2
                 anchors.fill: parent
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
@@ -258,17 +259,54 @@ KodiPage {
                 spacing: parent.width / 8
                 opacity: settings.introStep < Settings.IntroStepColors ? 0 : 1
                 Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
-                UbuntuShape { height: units.gu(2); width: parent.spacing; color: "red"; anchors.verticalCenter: parent.verticalCenter;
-                    AbstractButton { anchors.fill: parent; anchors.margins: -10; onClicked: { keys.red() } }
+
+                UbuntuShape {
+                    height: units.gu(2); width: parent.spacing; color: "red"; anchors.verticalCenter: parent.verticalCenter;
+                    AbstractButton {
+                        anchors.fill: parent; anchors.margins: -10;
+                        onClicked: {
+                            if (settings.introStep == Settings.IntroStepColors) {
+                                introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("red")
+                            }
+                            keys.red()
+                        }
+                    }
                 }
-                UbuntuShape { height: units.gu(2); width: parent.spacing; color: "green"; anchors.verticalCenter: parent.verticalCenter;
-                    AbstractButton { anchors.fill: parent; anchors.margins: -10; onClicked: { keys.green() } }
+                UbuntuShape {
+                    height: units.gu(2); width: parent.spacing; color: "green"; anchors.verticalCenter: parent.verticalCenter;
+                    AbstractButton {
+                        anchors.fill: parent; anchors.margins: -10;
+                        onClicked: {
+                            if (settings.introStep == Settings.IntroStepColors) {
+                                introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("green")
+                            }
+                            keys.green()
+                        }
+                    }
                 }
-                UbuntuShape { height: units.gu(2); width: parent.spacing; color: "yellow"; anchors.verticalCenter: parent.verticalCenter;
-                    AbstractButton { anchors.fill: parent; anchors.margins: -10; onClicked: { keys.yellow() } }
+                UbuntuShape {
+                    height: units.gu(2); width: parent.spacing; color: "yellow"; anchors.verticalCenter: parent.verticalCenter;
+                    AbstractButton {
+                        anchors.fill: parent; anchors.margins: -10;
+                        onClicked: {
+                            if (settings.introStep == Settings.IntroStepColors) {
+                                introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("yellow")
+                            }
+                            keys.yellow()
+                        }
+                    }
                 }
-                UbuntuShape { height: units.gu(2); width: parent.spacing; color: "blue"; anchors.verticalCenter: parent.verticalCenter;
-                    AbstractButton { anchors.fill: parent; anchors.margins: -10; onClicked: { keys.blue() } }
+                UbuntuShape {
+                    height: units.gu(2); width: parent.spacing; color: "blue"; anchors.verticalCenter: parent.verticalCenter;
+                    AbstractButton {
+                        anchors.fill: parent; anchors.margins: -10;
+                        onClicked: {
+                            if (settings.introStep == Settings.IntroStepColors) {
+                                introLabel2.text = qsTr("Remote name: %1<br>Button name: %2").arg("kodimote").arg("blue")
+                            }
+                            keys.blue()
+                        }
+                    }
                 }
             }
         }

--- a/apps/ubuntu/qml/Keypad.qml
+++ b/apps/ubuntu/qml/Keypad.qml
@@ -73,6 +73,8 @@ KodiPage {
                         return qsTr("To scroll through lists, press and keep holding while dragging.");
                     case Settings.IntroStepClick:
                         return qsTr("To select an item, tap anywhere on the pad.");
+                    case Settings.IntroStepColors:
+                        return qsTr("Pro tip: The color buttons at the bottom simulate an infrared remote.")
                     }
                     return ""
                 }
@@ -215,8 +217,16 @@ KodiPage {
                 verticalAlignment: Text.AlignVCenter
                 color: "white"
                 wrapMode: Text.WordWrap
-                text: settings.introStep == Settings.IntroStepScroll ? qsTr("The further you move, the faster you scroll.") : ""
-                opacity: settings.introStep == Settings.IntroStepScroll ? 1 : 0
+                text: {
+                    switch (settings.introStep) {
+                    case Settings.IntroStepScroll:
+                        return qsTr("The further you move, the faster you scroll.");
+                    case Settings.IntroStepColors:
+                        return qsTr("You can map them to anything you want in Kodi's Lircmap.xml")
+                    }
+                    return ""
+                }
+                opacity: (settings.introStep == Settings.IntroStepScroll || settings.introStep == Settings.IntroStepColors) ? 1 : 0
                 Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
             }
 
@@ -246,7 +256,7 @@ KodiPage {
                 anchors.centerIn: parent
                 height: controlButtons.height
                 spacing: parent.width / 8
-                opacity: settings.introStep < Settings.IntroStepDone ? 0 : 1
+                opacity: settings.introStep < Settings.IntroStepColors ? 0 : 1
                 Behavior on opacity { UbuntuNumberAnimation { duration: UbuntuAnimation.SlowDuration } }
                 UbuntuShape { height: units.gu(2); width: parent.spacing; color: "red"; anchors.verticalCenter: parent.verticalCenter;
                     AbstractButton { anchors.fill: parent; anchors.margins: -10; onClicked: { keys.red() } }

--- a/apps/ubuntu/qml/Keypad.qml
+++ b/apps/ubuntu/qml/Keypad.qml
@@ -274,8 +274,4 @@ KodiPage {
             }
         }
     }
-
-//    GesturesIntro {
-//        id: gesturesIntro
-//    }
 }

--- a/libkodimote/kodi.cpp
+++ b/libkodimote/kodi.cpp
@@ -53,7 +53,7 @@
 #include "keys.h"
 #include "eventclient.h"
 
-//#include "settings.h"
+#include "settings.h"
 
 #include "imagecache.h"
 
@@ -167,6 +167,8 @@ Kodi::Kodi(QObject *parent) :
     qmlRegisterType<KodiHostModel>();
     qmlRegisterType<KodiHost>(qmlUri, 1, 0, "KodiHost");
     qmlRegisterType<KodiDiscovery>(qmlUri, 1, 0, "KodiDiscovery");
+
+    qmlRegisterUncreatableType<Settings>("Kodi", 1, 0, "Settings", "Cannot create multiple settings. Use the \"settings\" context property intead");
 
     m_hosts = new KodiHostModel(this);
 

--- a/libkodimote/settings.cpp
+++ b/libkodimote/settings.cpp
@@ -211,3 +211,16 @@ void Settings::setHapticsEnabled(bool enabled)
     settings.setValue("HapticsEnabled", enabled);
     emit hapticsEnabledChanged();
 }
+
+Settings::IntroStep Settings::introStep() const
+{
+    QSettings settings;
+    return (IntroStep)settings.value("IntroStep", 0).toInt();
+}
+
+void Settings::setIntroStep(IntroStep introStep)
+{
+    QSettings settings;
+    settings.setValue("IntroStep", introStep);
+    emit introStepChanged();
+}

--- a/libkodimote/settings.h
+++ b/libkodimote/settings.h
@@ -27,6 +27,7 @@
 class Settings : public QObject
 {
     Q_OBJECT
+    Q_ENUMS(IntroStep)
     Q_PROPERTY(bool themeInverted READ themeInverted WRITE setThemeInverted NOTIFY themeInvertedChanged)
     Q_PROPERTY(bool useThumbnails READ useThumbnails WRITE setUseThumbnails NOTIFY useThumbnailsChanged)
     Q_PROPERTY(bool ignoreArticle READ ignoreArticle WRITE setIgnoreArticle NOTIFY ignoreArticleChanged)
@@ -41,8 +42,17 @@ class Settings : public QObject
     Q_PROPERTY(bool picturesEnabled READ picturesEnabled WRITE setPicturesEnabled NOTIFY picturesEnabledChanged)
     Q_PROPERTY(bool pvrEnabled READ pvrEnabled WRITE setPvrEnabled NOTIFY pvrEnabledChanged)
     Q_PROPERTY(bool hapticsEnabled READ hapticsEnabled WRITE setHapticsEnabled NOTIFY hapticsEnabledChanged)
+    Q_PROPERTY(IntroStep introStep READ introStep WRITE setIntroStep NOTIFY introStepChanged)
 
 public:
+    enum IntroStep {
+        IntroStepLeftRight,
+        IntroStepUpDown,
+        IntroStepScroll,
+        IntroStepClick,
+        IntroStepDone
+    };
+
     explicit Settings(QObject *parent = 0);
 
     void setThemeInverted(bool inverted);
@@ -87,6 +97,9 @@ public:
     bool hapticsEnabled() const;
     void setHapticsEnabled(bool enabled);
 
+    IntroStep introStep() const;
+    void setIntroStep(IntroStep introStep);
+
 signals:
     void themeInvertedChanged();
     void useThumbnailsChanged();
@@ -104,6 +117,7 @@ signals:
     void picturesEnabledChanged();
     void pvrEnabledChanged();
     void hapticsEnabledChanged();
+    void introStepChanged();
 };
 
 #endif // SETTINGS_H

--- a/libkodimote/settings.h
+++ b/libkodimote/settings.h
@@ -51,6 +51,7 @@ public:
         IntroStepScroll,
         IntroStepClick,
         IntroStepColors,
+        IntroStepExit,
         IntroStepDone
     };
 

--- a/libkodimote/settings.h
+++ b/libkodimote/settings.h
@@ -50,6 +50,7 @@ public:
         IntroStepUpDown,
         IntroStepScroll,
         IntroStepClick,
+        IntroStepColors,
         IntroStepDone
     };
 


### PR DESCRIPTION
Only done in Ubuntu so far. This is how it looks like: http://notyetthere.org/data/gestures-intro.ogv

 @RobertMe: can you do something similar for sailfish? All you need to do is to don't execute presses if settings.introStep < Settings.IntroStepDone and if the according IntroStep action is triggered, call settings.introStep++;