### PR TITLE
Fix authentication

### DIFF
--- a/libkodimote/kodiconnection.cpp
+++ b/libkodimote/kodiconnection.cpp
@@ -366,7 +366,7 @@ void KodiConnectionPrivate::replyReceived()
 
     if(reply->error() != QNetworkReply::NoError) {
         m_connectionError = tr("Connection failed: %1").arg(reply->errorString());
-        closeConnection();
+        closeConnection(reply->error() != QNetworkReply::AuthenticationRequiredError);
     }
 
     koDebug(XDAREA_CONNECTION) << "received reply:" << commands;

--- a/libkodimote/kodiconnection.cpp
+++ b/libkodimote/kodiconnection.cpp
@@ -498,8 +498,8 @@ void KodiConnectionPrivate::handleData(const QString &data)
 
 void KodiConnectionPrivate::clearPending()
 {
-    koDebug(XDAREA_CONNECTION) << "timeouttimer hit for comman" << m_commandId << m_currentPendingCommand.id() << m_currentPendingCommand.command();
-    if(m_commandId == m_versionRequestId) {
+    koDebug(XDAREA_CONNECTION) << "timeouttimer hit for command" << m_currentPendingCommand.id() << m_currentPendingCommand.command();
+    if(m_currentPendingCommand.id() == m_versionRequestId) {
         koDebug(XDAREA_CONNECTION) << "cannot ask for remote version... ";
         m_connectionError = tr("Connection to %1 timed out...").arg(m_host->hostname());
         emit m_notifier->connectionChanged();

--- a/libkodimote/kodiconnection.cpp
+++ b/libkodimote/kodiconnection.cpp
@@ -367,6 +367,7 @@ void KodiConnectionPrivate::replyReceived()
     if(reply->error() != QNetworkReply::NoError) {
         m_connectionError = tr("Connection failed: %1").arg(reply->errorString());
         closeConnection(reply->error() != QNetworkReply::AuthenticationRequiredError);
+        return;
     }
 
     koDebug(XDAREA_CONNECTION) << "received reply:" << commands;


### PR DESCRIPTION
Only reconnect when there was no authentication error.

Also contains some other minor fixes, related to error and timeout handling.