### PR TITLE
Remember watched filter for movies and TV shows

### DIFF
--- a/apps/sailfish/qml/pages/BrowserPage.qml
+++ b/apps/sailfish/qml/pages/BrowserPage.qml
@@ -31,6 +31,15 @@ Page {
 
     signal home();
 
+    Component.onCompleted: {
+        var setting = model.watchedFilterSetting;
+        if (setting) {
+            settings[setting + 'Changed'].connect(function() {
+                filterModel.hideWatched = !settings[setting];
+            });
+        }
+    }
+
     Component.onDestruction: {
         if (model) {
             model.exit();
@@ -41,6 +50,14 @@ Page {
         id: filterModel
         model: browserPage.model
         filterCaseSensitivity: Qt.CaseInsensitive
+        hideWatched: model.watchedFilterSetting ? !settings[model.watchedFilterSetting] : false
+
+        onHideWatchedChanged: {
+            var setting = model.watchedFilterSetting;
+            if (setting) {
+                settings[setting] = !hideWatched;
+            }
+        }
     }
 
     SilicaFlickable {
@@ -364,8 +381,9 @@ Page {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.verticalCenterOffset: -14
                     checked: !filterModel.hideWatched
-                    onCheckedChanged: {
-                        filterModel.hideWatched = !checked
+                    automaticCheck: false
+                    onClicked: {
+                        filterModel.hideWatched = !filterModel.hideWatched
                     }
                 }
 

--- a/apps/ubuntu/qml/BrowserPage.qml
+++ b/apps/ubuntu/qml/BrowserPage.qml
@@ -45,6 +45,12 @@ KodiPage {
     Component.onCompleted: {
         console.log("BrowserPage: setting model " + model)
         //filterModel.model = model
+        var setting = model.watchedFilterSetting;
+        if (setting) {
+            settings[setting + 'Changed'].connect(function() {
+                filterModel.hideWatched = !settings[setting];
+            });
+        }
     }
 
     Component.onDestruction: {
@@ -98,6 +104,14 @@ KodiPage {
         model: root.model
         filterCaseSensitivity: Qt.CaseInsensitive
         filter: searchTextField.text
+        hideWatched: model.watchedFilterSetting ? !settings[model.watchedFilterSetting] : false
+
+        onHideWatchedChanged: {
+            var setting = model.watchedFilterSetting;
+            if (setting) {
+                settings[setting] = !hideWatched;
+            }
+        }
     }
 
     Item {

--- a/libkodimote/episodes.h
+++ b/libkodimote/episodes.h
@@ -45,6 +45,7 @@ public:
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatLandscape; }
     bool allowWatchedFilter() { return true; }
+    QString watchedFilterSetting() { return "showWatchedTvShows"; }
 
 public slots:
     void refresh();

--- a/libkodimote/kodimodel.h
+++ b/libkodimote/kodimodel.h
@@ -38,6 +38,7 @@ class KodiModel : public QAbstractItemModel
     Q_PROPERTY(ThumbnailFormat thumbnailFormat READ thumbnailFormat NOTIFY thumbnailFormatChanged)
     Q_PROPERTY(bool allowSearch READ allowSearch NOTIFY allowSearchChanged)
     Q_PROPERTY(bool allowWatchedFilter READ allowWatchedFilter NOTIFY allowWatchedFilterChanged)
+    Q_PROPERTY(QString watchedFilterSetting READ watchedFilterSetting NOTIFY watchedFilterSettingChanged)
 
 public:
     enum Roles {
@@ -140,6 +141,7 @@ public:
     virtual ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatSquare; }
     virtual bool allowSearch() { return true; }
     virtual bool allowWatchedFilter() { return false; }
+    virtual QString watchedFilterSetting() { return QString(); }
 
     Q_INVOKABLE void imageFetched(int id);
 public slots:
@@ -153,6 +155,7 @@ signals:
     void thumbnailFormatChanged();
     void allowSearchChanged();
     void allowWatchedFilterChanged();
+    void watchedFilterSettingChanged();
 
 protected:
     KodiModel *m_parentModel;

--- a/libkodimote/movies.h
+++ b/libkodimote/movies.h
@@ -46,6 +46,7 @@ public:
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatPortrait; }
     bool allowWatchedFilter() { return true; }
+    QString watchedFilterSetting() { return "showWatchedMovies"; }
 
 public slots:
     void refresh();

--- a/libkodimote/seasons.h
+++ b/libkodimote/seasons.h
@@ -42,6 +42,7 @@ public:
 
     KodiModel::ThumbnailFormat thumbnailFormat() const { return KodiModel::ThumbnailFormatPortrait; }
     bool allowWatchedFilter() { return true; }
+    QString watchedFilterSetting() { return "showWatchedTvShows"; }
 
 public slots:
     void refresh();

--- a/libkodimote/settings.cpp
+++ b/libkodimote/settings.cpp
@@ -224,3 +224,37 @@ void Settings::setIntroStep(IntroStep introStep)
     settings.setValue("IntroStep", introStep);
     emit introStepChanged();
 }
+
+bool Settings::showWatchedMovies() const
+{
+    QSettings settings;
+    return settings.value("ShowWatchedMovies", true).toBool();
+}
+
+void Settings::setShowWatchedMovies(bool show)
+{
+    QSettings settings;
+    if (settings.value("ShowWatchedMovies", true).toBool() == show) {
+        return;
+    }
+
+    settings.setValue("ShowWatchedMovies", show);
+    emit showWatchedMoviesChanged();
+}
+
+bool Settings::showWatchedTvShows() const
+{
+    QSettings settings;
+    return settings.value("ShowWatchedTvShows", true).toBool();
+}
+
+void Settings::setShowWatchedTvShows(bool show)
+{
+    QSettings settings;
+    if (settings.value("ShowWatchedTvShows", true).toBool() == show) {
+        return;
+    }
+
+    settings.setValue("ShowWatchedTvShows", show);
+    emit showWatchedTvShowsChanged();
+}

--- a/libkodimote/settings.h
+++ b/libkodimote/settings.h
@@ -43,6 +43,8 @@ class Settings : public QObject
     Q_PROPERTY(bool pvrEnabled READ pvrEnabled WRITE setPvrEnabled NOTIFY pvrEnabledChanged)
     Q_PROPERTY(bool hapticsEnabled READ hapticsEnabled WRITE setHapticsEnabled NOTIFY hapticsEnabledChanged)
     Q_PROPERTY(IntroStep introStep READ introStep WRITE setIntroStep NOTIFY introStepChanged)
+    Q_PROPERTY(bool showWatchedMovies READ showWatchedMovies WRITE setShowWatchedMovies NOTIFY showWatchedMoviesChanged)
+    Q_PROPERTY(bool showWatchedTvShows READ showWatchedTvShows WRITE setShowWatchedTvShows NOTIFY showWatchedTvShowsChanged)
 
 public:
     enum IntroStep {
@@ -102,6 +104,12 @@ public:
     IntroStep introStep() const;
     void setIntroStep(IntroStep introStep);
 
+    bool showWatchedMovies() const;
+    void setShowWatchedMovies(bool show);
+
+    bool showWatchedTvShows() const;
+    void setShowWatchedTvShows(bool show);
+
 signals:
     void themeInvertedChanged();
     void useThumbnailsChanged();
@@ -120,6 +128,8 @@ signals:
     void pvrEnabledChanged();
     void hapticsEnabledChanged();
     void introStepChanged();
+    void showWatchedMoviesChanged();
+    void showWatchedTvShowsChanged();
 };
 
 #endif // SETTINGS_H

--- a/libkodimote/tvshows.h
+++ b/libkodimote/tvshows.h
@@ -43,6 +43,7 @@ public:
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatLandscape; }
     bool allowWatchedFilter() { return true; }
+    QString watchedFilterSetting() { return "showWatchedTvShows"; }
 
 public slots:
     void refresh();


### PR DESCRIPTION
This fixes #17, and will remember the watched filter for both movies and TV shows independent of each other (but filter is reused for TV shows, seasons, and episodes, like Kodi does).

- [x] Implement setting in lib
- [x] Update Sailfish
- [x] Update Ubuntu (untested)

@mzanetti there is no rush to merge this, it's just a new feature for "2.1.0".