### PR TITLE
fix scrolling in gesturepad

### DIFF
--- a/apps/sailfish/qml/components/GesturePad.qml
+++ b/apps/sailfish/qml/components/GesturePad.qml
@@ -239,15 +239,6 @@ Item {
                     speed = newSpeed;
                     newSpeed = -1;
                 }
-
-                if (settings.introStep < Settings.IntroStepDone) {
-                    if (settings.introStep == Settings.IntroStepScroll) {
-                        rumbleEffect.start(1);
-                        settings.introStep++;
-                    }
-                    return;
-                }
-
                 mouseArea.doKeyPress(true);
             }
         }
@@ -294,6 +285,11 @@ Item {
 
             if (settings.hapticsEnabled) {
                 rumbleEffect.start(2);
+            }
+
+            if (settings.introStep == Settings.IntroStepScroll && repeated) {
+                settings.introStep++;
+                return;
             }
 
             // if horizontal delta is larger than twice the minimum distance,

--- a/apps/sailfish/qml/components/GesturePad.qml
+++ b/apps/sailfish/qml/components/GesturePad.qml
@@ -187,20 +187,12 @@ Item {
         onPressed: {
             startx = mouse.x
             starty = mouse.y
-        }
-
-        onPressAndHold: {
-            if (settings.hapticsEnabled) {
-                rumbleEffect.start(4);
-            }
-
             scrollTimer.start();
         }
 
         onReleased: {
-            if (scrollTimer.running) {
-                scrollTimer.stop();
-            } else {
+            scrollTimer.stop();
+            if (scrollTimer.triggerCount == 0) {
                 doKeyPress();
             }
         }
@@ -233,8 +225,16 @@ Item {
             // Lets use newSpeed for changing and fetch it when appropriate
             property int newSpeed: -1
 
-            property int introScrollCount: 0
+            property int triggerCount: 0
+
+            onRunningChanged: {
+                if (running) {
+                    triggerCount = 0;
+                }
+            }
+
             onTriggered: {
+                triggerCount++;
                 if(newSpeed !== -1) {
                     speed = newSpeed;
                     newSpeed = -1;
@@ -243,10 +243,7 @@ Item {
                 if (settings.introStep < Settings.IntroStepDone) {
                     if (settings.introStep == Settings.IntroStepScroll) {
                         rumbleEffect.start(1);
-                        introScrollCount++;
-                        if (introScrollCount >= 10) {
-                            settings.introStep++;
-                        }
+                        settings.introStep++;
                     }
                     return;
                 }

--- a/apps/sailfish/qml/components/GesturePad.qml
+++ b/apps/sailfish/qml/components/GesturePad.qml
@@ -193,7 +193,7 @@ Item {
         onReleased: {
             scrollTimer.stop();
             if (scrollTimer.triggerCount == 0) {
-                doKeyPress();
+                doKeyPress(false);
             }
         }
 
@@ -248,11 +248,11 @@ Item {
                     return;
                 }
 
-                mouseArea.doKeyPress();
+                mouseArea.doKeyPress(true);
             }
         }
 
-        function doKeyPress() {
+        function doKeyPress(repeated) {
             var dx = mouseX - startx;
             var dy = mouseY - starty;
             var dxAbs = Math.abs(dx);
@@ -261,6 +261,11 @@ Item {
             // Did we not move? => press enter
             if (dxAbs < maxClickDistance && dyAbs < maxClickDistance) {
                 print("pressing enter");
+
+                if (repeated) {
+                    // Do not trigger repeated enter presses
+                    return
+                }
 
                 if (settings.hapticsEnabled) {
                     rumbleEffect.start(1);

--- a/apps/sailfish/qml/components/GesturePad.qml
+++ b/apps/sailfish/qml/components/GesturePad.qml
@@ -260,8 +260,6 @@ Item {
 
             // Did we not move? => press enter
             if (dxAbs < maxClickDistance && dyAbs < maxClickDistance) {
-                print("pressing enter");
-
                 if (repeated) {
                     // Do not trigger repeated enter presses
                     return

--- a/apps/sailfish/qml/components/GesturePad.qml
+++ b/apps/sailfish/qml/components/GesturePad.qml
@@ -304,7 +304,7 @@ Item {
             // just by touching the screen with more than the tip
             if (dxAbs > minSwipeDistance * 2 || dxAbs > dyAbs) {
                 if (settings.introStep < Settings.IntroStepDone) {
-                    if (settings.introStep == Settings.IntroStepLeftRight) {
+                    if (settings.introStep == Settings.IntroStepLeftRight && !repeated) {
                         settings.introStep++;
                     }
                     return;
@@ -319,7 +319,7 @@ Item {
                 }
             } else {
                 if (settings.introStep < Settings.IntroStepDone) {
-                    if (settings.introStep == Settings.IntroStepUpDown) {
+                    if (settings.introStep == Settings.IntroStepUpDown && !repeated) {
                         settings.introStep++;
                     }
                     return;

--- a/apps/sailfish/qml/components/GesturePad.qml
+++ b/apps/sailfish/qml/components/GesturePad.qml
@@ -29,6 +29,8 @@ Item {
     height: bgImage.height
     width: parent.width
 
+    property int scrollCounter: 0
+
     HapticsEffect {
         id: rumbleEffect
         intensity: 0.05
@@ -288,7 +290,11 @@ Item {
             }
 
             if (settings.introStep == Settings.IntroStepScroll && repeated) {
-                settings.introStep++;
+                if (root.scrollCounter < 9) {
+                    root.scrollCounter++;
+                } else {
+                    settings.introStep++;
+                }
                 return;
             }
 

--- a/apps/sailfish/qml/pages/Keypad.qml
+++ b/apps/sailfish/qml/pages/Keypad.qml
@@ -137,7 +137,7 @@ Page {
                         case Settings.IntroStepUpDown:
                             return qsTr("To move up or down, swipe vertically.");
                         case Settings.IntroStepScroll:
-                            return qsTr("To scroll through lists, press and keep holding while dragging.");
+                            return qsTr("Keep holding after swiping to scroll though lists quickly.");
                         case Settings.IntroStepClick:
                             return qsTr("To select an item, tap anywhere on the pad.");
                         case Settings.IntroStepColors:

--- a/apps/sailfish/qml/pages/Keypad.qml
+++ b/apps/sailfish/qml/pages/Keypad.qml
@@ -137,7 +137,14 @@ Page {
                         case Settings.IntroStepUpDown:
                             return qsTr("To move up or down, swipe vertically.");
                         case Settings.IntroStepScroll:
-                            return qsTr("Keep holding after swiping to scroll though lists quickly.");
+                            switch (gesturePad.scrollCounter) {
+                            case 0:
+                                return qsTr("To scroll through lists keep holding after swiping.");
+                            case 1:
+                                return qsTr("You've scrolled 1 time, keep holding to scroll another 9 times.");
+                            default:
+                                return qsTr("You've scrolled %1 times, keep holding to scroll another %2 times.").arg(gesturePad.scrollCounter).arg(10 - gesturePad.scrollCounter);
+                            }
                         case Settings.IntroStepClick:
                             return qsTr("To select an item, tap anywhere on the pad.");
                         case Settings.IntroStepColors:

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -185,17 +185,12 @@ Item {
         onPressed: {
             startx = mouse.x
             starty = mouse.y
-        }
-
-        onPressAndHold: {
-//            rumbleEffect.start(4);
             scrollTimer.start();
         }
 
         onReleased: {
-            if (scrollTimer.running) {
-                scrollTimer.stop();
-            } else {
+            scrollTimer.stop();
+            if (scrollTimer.triggerCount == 0) {
                 doKeyPress();
             }
         }
@@ -228,8 +223,16 @@ Item {
             // Lets use newSpeed for changing and fetch it when appropriate
             property int newSpeed: -1
 
-            property int introScrollCount: 0
+            property int triggerCount: 0
+
+            onRunningChanged: {
+                if (running) {
+                    triggerCount = 0;
+                }
+            }
+
             onTriggered: {
+                triggerCount++;
                 if(newSpeed !== -1) {
                     speed = newSpeed;
                     newSpeed = -1;
@@ -237,10 +240,7 @@ Item {
                 if (settings.introStep < Settings.IntroStepDone) {
                     if (settings.introStep == Settings.IntroStepScroll) {
                         rumbleEffect.start(1);
-                        introScrollCount++;
-                        if (introScrollCount >= 10) {
-                            settings.introStep++;
-                        }
+                        settings.introStep++;
                     }
                     return;
                 }

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -26,6 +26,8 @@ import Kodi 1.0
 Item {
     id: root
 
+    property int scrollCounter: 0
+
     Timer {
         id: teaseTimer
         interval: 1000
@@ -280,7 +282,11 @@ Item {
             rumbleEffect.start(1);
 
             if (settings.introStep == Settings.IntroStepScroll && repeated) {
-                settings.introStep++;
+                if (root.scrollCounter < 9) {
+                    root.scrollCounter++;
+                } else {
+                    settings.introStep++;
+                }
                 return;
             }
 

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -237,14 +237,6 @@ Item {
                     speed = newSpeed;
                     newSpeed = -1;
                 }
-                if (settings.introStep < Settings.IntroStepDone) {
-                    if (settings.introStep == Settings.IntroStepScroll) {
-                        rumbleEffect.start(1);
-                        settings.introStep++;
-                    }
-                    return;
-                }
-
                 mouseArea.doKeyPress(true);
             }
         }
@@ -286,6 +278,11 @@ Item {
             }
 
             rumbleEffect.start(1);
+
+            if (settings.introStep == Settings.IntroStepScroll && repeated) {
+                settings.introStep++;
+                return;
+            }
 
             // if horizontal delta is larger than twice the minimum distance,
             // we always go left/right, no matter what the vertical delta is.

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -191,7 +191,7 @@ Item {
         onReleased: {
             scrollTimer.stop();
             if (scrollTimer.triggerCount == 0) {
-                doKeyPress();
+                doKeyPress(false);
             }
         }
 
@@ -234,6 +234,7 @@ Item {
             onTriggered: {
                 triggerCount++;
                 if(newSpeed !== -1) {
+                    console.log("newspeed = " + newSpeed);
                     speed = newSpeed;
                     newSpeed = -1;
                 }
@@ -245,11 +246,11 @@ Item {
                     return;
                 }
 
-                mouseArea.doKeyPress();
+                mouseArea.doKeyPress(true);
             }
         }
 
-        function doKeyPress() {
+        function doKeyPress(repeated) {
             var dx = mouseX - startx;
             var dy = mouseY - starty;
             var dxAbs = Math.abs(dx);
@@ -257,6 +258,11 @@ Item {
 
             // Did we not move? => press enter
             if (dxAbs < maxClickDistance && dyAbs < maxClickDistance) {
+                if (repeated) {
+                    // Do not trigger repeated enter presses
+                    return;
+                }
+
                 print("pressing enter")
                 if (settings.introStep < Settings.IntroStepDone) {
                     if (settings.introStep == Settings.IntroStepClick || settings.introStep == Settings.IntroStepColors) {

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -234,7 +234,6 @@ Item {
             onTriggered: {
                 triggerCount++;
                 if(newSpeed !== -1) {
-                    console.log("newspeed = " + newSpeed);
                     speed = newSpeed;
                     newSpeed = -1;
                 }

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -296,7 +296,7 @@ Item {
             // just by touching the screen with more than the tip
             if (dxAbs > minSwipeDistance * 2 || dxAbs > dyAbs) {
                 if (settings.introStep < Settings.IntroStepDone) {
-                    if (settings.introStep == Settings.IntroStepLeftRight) {
+                    if (settings.introStep == Settings.IntroStepLeftRight && !repeated) {
                         settings.introStep++;
                     }
                     return;
@@ -311,7 +311,7 @@ Item {
                 }
             } else {
                 if (settings.introStep < Settings.IntroStepDone) {
-                    if (settings.introStep == Settings.IntroStepUpDown) {
+                    if (settings.introStep == Settings.IntroStepUpDown && !repeated) {
                         settings.introStep++;
                     }
                     return;

--- a/apps/ubuntu/qml/GesturePad.qml
+++ b/apps/ubuntu/qml/GesturePad.qml
@@ -262,8 +262,6 @@ Item {
                     // Do not trigger repeated enter presses
                     return;
                 }
-
-                print("pressing enter")
                 if (settings.introStep < Settings.IntroStepDone) {
                     if (settings.introStep == Settings.IntroStepClick || settings.introStep == Settings.IntroStepColors) {
                         settings.introStep++;

--- a/apps/ubuntu/qml/Keypad.qml
+++ b/apps/ubuntu/qml/Keypad.qml
@@ -67,7 +67,14 @@ KodiPage {
                     case Settings.IntroStepUpDown:
                         return qsTr("To move up or down, swipe vertically.");
                     case Settings.IntroStepScroll:
-                        return qsTr("Keep holding after swiping to scroll though lists quickly.");
+                        switch (gesturePad.scrollCounter) {
+                        case 0:
+                            return qsTr("To scroll through lists keep holding after swiping.");
+                        case 1:
+                            return qsTr("You've scrolled 1 time, keep holding to scroll another 9 times.");
+                        default:
+                            return qsTr("You've scrolled %1 times, keep holding to scroll another %2 times.").arg(gesturePad.scrollCounter).arg(10 - gesturePad.scrollCounter);
+                        }
                     case Settings.IntroStepClick:
                         return qsTr("To select an item, tap anywhere on the pad.");
                     case Settings.IntroStepColors:

--- a/apps/ubuntu/qml/Keypad.qml
+++ b/apps/ubuntu/qml/Keypad.qml
@@ -67,7 +67,7 @@ KodiPage {
                     case Settings.IntroStepUpDown:
                         return qsTr("To move up or down, swipe vertically.");
                     case Settings.IntroStepScroll:
-                        return qsTr("To scroll through lists, press and keep holding while dragging.");
+                        return qsTr("Keep holding after swiping to scroll though lists quickly.");
                     case Settings.IntroStepClick:
                         return qsTr("To select an item, tap anywhere on the pad.");
                     case Settings.IntroStepColors:


### PR DESCRIPTION
Fixes #47 

This makes the scrolling work much better which should prevent people getting stuck in the intro. I've removed the minimum scroll distance because that really is an issue if there's no haptics feedback like in harbor. So somehow dragging and not releasing immediately will get you past the intro step.