### PR TITLE
add a generic media type to kodimodel.

### DIFF
--- a/apps/ubuntu/qml/BrowserPage.qml
+++ b/apps/ubuntu/qml/BrowserPage.qml
@@ -299,6 +299,25 @@ KodiPage {
                                     height: thumbnailImage.height
                                 }
                             }
+
+                            Icon {
+                                anchors.centerIn: parent
+                                width: Math.min(parent.width, parent.height) - units.gu(1)
+                                height: width
+                                name: {
+                                    switch (root.model.mediaFormat) {
+                                    case KodiModel.MediaFormatAudio:
+                                        return "audio-x-generic-symbolic";
+                                    case KodiModel.MediaFormatVideo:
+                                        return "video-x-generic-symbolic";
+                                    case KodiModel.MediaFormatPictures:
+                                        return "image-x-generic-symbolic";
+                                    }
+                                    return "empty-symbolic";
+                                }
+                                color: "white"
+                                visible: !thumbnail || thumbnail == "loading"
+                            }
                         }
                     }
                     Column {

--- a/libkodimote/addonsource.h
+++ b/libkodimote/addonsource.h
@@ -12,6 +12,17 @@ public:
     QString title() const;
     KodiModel *enterItem(int index);
 
+    MediaFormat mediaFormat() const {
+        if (m_mediaType == "music") {
+            return MediaFormatAudio;
+        } else if (m_mediaType == "video") {
+            return MediaFormatVideo;
+        } else if (m_mediaType == "pictures") {
+            return MediaFormatPictures;
+        }
+        return MediaFormatUnknown;
+    }
+
 protected:
     QString parseTitle(const QString &title) const;
     bool filterFile(const QVariantMap &item) const;

--- a/libkodimote/addonsource.h
+++ b/libkodimote/addonsource.h
@@ -12,17 +12,6 @@ public:
     QString title() const;
     KodiModel *enterItem(int index);
 
-    MediaFormat mediaFormat() const {
-        if (m_mediaType == "music") {
-            return MediaFormatAudio;
-        } else if (m_mediaType == "video") {
-            return MediaFormatVideo;
-        } else if (m_mediaType == "pictures") {
-            return MediaFormatPictures;
-        }
-        return MediaFormatUnknown;
-    }
-
 protected:
     QString parseTitle(const QString &title) const;
     bool filterFile(const QVariantMap &item) const;

--- a/libkodimote/albums.h
+++ b/libkodimote/albums.h
@@ -45,6 +45,8 @@ public:
 
     Q_INVOKABLE virtual void download(int index, const QString &path);
 
+    MediaFormat mediaFormat() const { return MediaFormatAudio; }
+
 public slots:
     void refresh();
 

--- a/libkodimote/artists.h
+++ b/libkodimote/artists.h
@@ -45,6 +45,8 @@ public:
 
     Q_INVOKABLE virtual void download(int index, const QString &path);
 
+    MediaFormat mediaFormat() const { return MediaFormatAudio; }
+
 public slots:
     void refresh();
 

--- a/libkodimote/audiolibrary.cpp
+++ b/libkodimote/audiolibrary.cpp
@@ -86,9 +86,9 @@ KodiModel *AudioLibrary::enterItem(int index)
     case 3:
         return new Genres(this);
     case 4:
-        return new RecentItems(RecentItems::ModeAudio, RecentItems::RecentlyAdded, this);
+        return new RecentItems(MediaFormatAudio, RecentItems::RecentlyAdded, this);
     case 5:
-        return new RecentItems(RecentItems::ModeAudio, RecentItems::RecentlyPlayed, this);
+        return new RecentItems(MediaFormatAudio, RecentItems::RecentlyPlayed, this);
     case 6:
         return new AddonSource(tr("Music Add-ons"), "music", "addons://sources/audio", this);
     case 7:

--- a/libkodimote/audiolibrary.h
+++ b/libkodimote/audiolibrary.h
@@ -40,6 +40,7 @@ public:
     bool allowSearch();
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatNone; }
+    MediaFormat mediaFormat() const { return MediaFormatAudio; }
 
 public slots:
     void scanForContent();

--- a/libkodimote/audioplaylist.h
+++ b/libkodimote/audioplaylist.h
@@ -42,6 +42,8 @@ public:
     QString title() const;
     int playlistId() const;
 
+    MediaFormat mediaFormat() const { return MediaFormatAudio; }
+
 public slots:
     void refresh();
 

--- a/libkodimote/channels.h
+++ b/libkodimote/channels.h
@@ -39,6 +39,7 @@ public:
     virtual QVariant data(const QModelIndex &index, int role) const;
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormat43; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
     Q_INVOKABLE void fetchItemDetails(int index);
     Q_INVOKABLE bool hasDetails() { return true; }
 

--- a/libkodimote/episodes.h
+++ b/libkodimote/episodes.h
@@ -44,6 +44,7 @@ public:
     Q_INVOKABLE void download(int index, const QString &path);
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatLandscape; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
     bool allowWatchedFilter() { return true; }
 
 public slots:

--- a/libkodimote/files.h
+++ b/libkodimote/files.h
@@ -36,6 +36,17 @@ public:
     QString title() const;
     Q_INVOKABLE void download(int index, const QString &path);
 
+    MediaFormat mediaFormat() const {
+        if (m_mediaType == "music") {
+            return MediaFormatAudio;
+        } else if (m_mediaType == "video") {
+            return MediaFormatVideo;
+        } else if (m_mediaType == "pictures") {
+            return MediaFormatPictures;
+        }
+        return MediaFormatUnknown;
+    }
+
 public slots:
     void refresh();
 

--- a/libkodimote/genres.h
+++ b/libkodimote/genres.h
@@ -40,6 +40,8 @@ public:
 
     Q_INVOKABLE bool hasDetails() { return false; }
 
+    MediaFormat mediaFormat() const { return MediaFormatAudio; }
+
 public slots:
     void refresh();
 

--- a/libkodimote/imagecache.cpp
+++ b/libkodimote/imagecache.cpp
@@ -144,7 +144,6 @@ void KodiImageCache::imageFetched()
     reply->deleteLater();
 
     if(reply->error() == QNetworkReply::NoError) {
-        job->setParent(this);
         QFutureWatcher<ImageFetchJob*> *watcher = new QFutureWatcher<ImageFetchJob*>();
         connect(watcher, SIGNAL(finished()), this, SLOT(imageScaled()));
         watcher->setFuture(QtConcurrent::run(scaleImage, job, reply->readAll()));

--- a/libkodimote/imagecache.cpp
+++ b/libkodimote/imagecache.cpp
@@ -149,28 +149,20 @@ void KodiImageCache::imageFetched()
         connect(watcher, SIGNAL(finished()), this, SLOT(imageScaled()));
         watcher->setFuture(QtConcurrent::run(scaleImage, job, reply->readAll()));
         return;
-    } else {
-        qDebug() << "image fetching failed" << reply->errorString() << reply->error();
+    }
 
-        // Hack: There is something fishy with Kodi's image urls. Some versions require decoding
-        // from PercentageDecoding once, some twice... Let's retry doubleDecoding if if we get a 404
-        if (reply->error() == QNetworkReply::ContentNotFoundError) {
-            if (!m_doubleDecode) {
-                m_doubleDecode = true;
-                fetchNext(job);
-                return;
-            } else {
-                // So this failed with both... Lets turn off doubleDecode again and try the next
-                m_doubleDecode = false;
-            }
-        }
+    qDebug() << "image fetching failed" << reply->errorString() << reply->error();
 
-
-        QVariant possibleRedirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
-        qDebug() << possibleRedirectUrl;
-
-        if(!possibleRedirectUrl.toString().isEmpty() && possibleRedirectUrl != reply->url()) {
-            qDebug() << "We got redirected to" << possibleRedirectUrl;
+    // Hack: There is something fishy with Kodi's image urls. Some versions require decoding
+    // from PercentageDecoding once, some twice... Let's retry doubleDecoding if if we get a 404
+    if (reply->error() == QNetworkReply::ContentNotFoundError) {
+        if (!m_doubleDecode) {
+            m_doubleDecode = true;
+            fetchNext(job);
+            return;
+        } else {
+            // So this failed with both... Lets turn off doubleDecode again and try the next
+            m_doubleDecode = false;
         }
     }
 

--- a/libkodimote/imagecache.cpp
+++ b/libkodimote/imagecache.cpp
@@ -165,6 +165,7 @@ void KodiImageCache::imageFetched()
             }
         }
 
+
         QVariant possibleRedirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
         qDebug() << possibleRedirectUrl;
 
@@ -173,6 +174,12 @@ void KodiImageCache::imageFetched()
         }
     }
 
+    foreach (const ImageFetchJob::Callback callback, job->callbacks()) {
+        QMetaObject::invokeMethod(callback.object().data(), callback.method().toLatin1(), Qt::QueuedConnection, Q_ARG(int, job->id()));
+    }
+
+    job->deleteLater();
+    m_cacheFiles.insert(cacheKey, qMakePair<bool, QString>(true, ""));
     m_jobs.remove(cacheKey);
 }
 

--- a/libkodimote/kodimodel.h
+++ b/libkodimote/kodimodel.h
@@ -31,11 +31,13 @@ class KodiModel : public QAbstractItemModel
     Q_OBJECT
     Q_ENUMS(ThumbnailFormat)
     Q_ENUMS(LockMode)
+    Q_ENUMS(MediaFormat)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(int count READ rowCount NOTIFY layoutChanged)
     Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
     Q_PROPERTY(bool ignoreArticle READ ignoreArticle WRITE setIgnoreArticle NOTIFY ignoreArticleChanged)
     Q_PROPERTY(ThumbnailFormat thumbnailFormat READ thumbnailFormat NOTIFY thumbnailFormatChanged)
+    Q_PROPERTY(MediaFormat mediaFormat READ mediaFormat CONSTANT)
     Q_PROPERTY(bool allowSearch READ allowSearch NOTIFY allowSearchChanged)
     Q_PROPERTY(bool allowWatchedFilter READ allowWatchedFilter NOTIFY allowWatchedFilterChanged)
 
@@ -95,6 +97,13 @@ public:
         ThumbnailFormat43
     };
 
+    enum MediaFormat {
+        MediaFormatUnknown,
+        MediaFormatAudio,
+        MediaFormatVideo,
+        MediaFormatPictures
+    };
+
     enum ItemId {
         ItemIdInvalid = -1,
         ItemIdRecentlyAdded = -2,
@@ -138,6 +147,7 @@ public:
     void setIgnoreArticle(bool ignoreArticle);
 
     virtual ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatSquare; }
+    virtual MediaFormat mediaFormat() const { return MediaFormatUnknown; }
     virtual bool allowSearch() { return true; }
     virtual bool allowWatchedFilter() { return false; }
 

--- a/libkodimote/movies.h
+++ b/libkodimote/movies.h
@@ -45,6 +45,7 @@ public:
     Q_INVOKABLE virtual void download(int index, const QString &path);
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatPortrait; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
     bool allowWatchedFilter() { return true; }
 
 public slots:

--- a/libkodimote/musicvideos.h
+++ b/libkodimote/musicvideos.h
@@ -40,6 +40,8 @@ public:
     Q_INVOKABLE void fetchItemDetails(int index);
     Q_INVOKABLE bool hasDetails() { return true; }
 
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
+
 public slots:
     void refresh();
 

--- a/libkodimote/pictureplaylist.h
+++ b/libkodimote/pictureplaylist.h
@@ -36,6 +36,8 @@ public:
     void refresh() {}
     void queryItemData(int) {}
 
+    MediaFormat mediaFormat() const { return MediaFormatPictures; }
+
 private slots:
     void receivedAnnouncement(const QVariantMap &map);
 

--- a/libkodimote/pvrmenu.h
+++ b/libkodimote/pvrmenu.h
@@ -35,6 +35,7 @@ public:
     void addToPlaylist(int index);
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatNone; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
 
 public slots:
     void refresh();

--- a/libkodimote/recentitems.cpp
+++ b/libkodimote/recentitems.cpp
@@ -28,12 +28,13 @@
 #include "kodiconnection.h"
 #include "libraryitem.h"
 
-RecentItems::RecentItems(Mode mode, RecentlyWhat what, KodiLibrary *parent):
+RecentItems::RecentItems(MediaFormat mediaFormat, RecentlyWhat what, KodiLibrary *parent):
     KodiLibrary(parent),
+    m_mediaFormat(mediaFormat),
     m_what(what)
 {
     setBusy(false);
-    if (mode == ModeAudio) {
+    if (mediaFormat == MediaFormatAudio) {
         LibraryItem *item = new LibraryItem(tr("Albums"), QString(), this);
         item->setFileType("directory");
         item->setPlayable(false);
@@ -45,7 +46,7 @@ RecentItems::RecentItems(Mode mode, RecentlyWhat what, KodiLibrary *parent):
         item->setPlayable(false);
         item->setProperty("id", 1);
         m_list.append(item);
-    } else if (mode == ModeVideo) {
+    } else if (mediaFormat == MediaFormatVideo) {
         LibraryItem *item = new LibraryItem(tr("Movies"), QString(), this);
         item->setFileType("directory");
         item->setPlayable(false);

--- a/libkodimote/recentitems.h
+++ b/libkodimote/recentitems.h
@@ -29,16 +29,12 @@ class RecentItems : public KodiLibrary
 {
     Q_OBJECT
 public:
-    enum Mode {
-        ModeAudio,
-        ModeVideo
-    };
     enum RecentlyWhat {
         RecentlyPlayed,
         RecentlyAdded
     };
 
-    explicit RecentItems(Mode mode, RecentlyWhat what, KodiLibrary *parent);
+    explicit RecentItems(MediaFormat mediaFormat, RecentlyWhat what, KodiLibrary *parent);
     
     KodiModel *enterItem(int index);
     void playItem(int index);
@@ -49,11 +45,13 @@ public:
     bool allowSearch();
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatNone; }
+    MediaFormat mediaFormat() const {  return m_mediaFormat; }
 
 public slots:
     void refresh();
 
 private:
+    MediaFormat m_mediaFormat;
     RecentlyWhat m_what;
 };
 

--- a/libkodimote/recordings.h
+++ b/libkodimote/recordings.h
@@ -38,6 +38,7 @@ public:
     virtual QHash<int, QByteArray> roleNames() const;
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatPortrait; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
     Q_INVOKABLE void fetchItemDetails(int index);
     Q_INVOKABLE bool hasDetails() { return true; }
 

--- a/libkodimote/seasons.h
+++ b/libkodimote/seasons.h
@@ -40,7 +40,8 @@ public:
     Q_INVOKABLE void fetchItemDetails(int index);
     Q_INVOKABLE bool hasDetails() { return true; }
 
-    KodiModel::ThumbnailFormat thumbnailFormat() const { return KodiModel::ThumbnailFormatPortrait; }
+    ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatPortrait; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
     bool allowWatchedFilter() { return true; }
 
 public slots:

--- a/libkodimote/shares.h
+++ b/libkodimote/shares.h
@@ -37,6 +37,17 @@ public:
 
     bool allowSearch();
 
+    MediaFormat mediaFormat() const {
+        if (m_mediaType == "music") {
+            return MediaFormatAudio;
+        } else if (m_mediaType == "video") {
+            return MediaFormatVideo;
+        } else if (m_mediaType == "pictures") {
+            return MediaFormatPictures;
+        }
+        return MediaFormatUnknown;
+    }
+
 public slots:
     void refresh();
 

--- a/libkodimote/songs.h
+++ b/libkodimote/songs.h
@@ -42,6 +42,8 @@ public:
 
     Q_INVOKABLE void download(int index, const QString &path);
 
+    MediaFormat mediaFormat() const { return MediaFormatAudio; }
+
 public slots:
     void refresh() { refresh(0, 200); }
     void refresh(int start, int end);

--- a/libkodimote/tvshows.h
+++ b/libkodimote/tvshows.h
@@ -42,6 +42,7 @@ public:
     Q_INVOKABLE bool hasDetails() { return true; }
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatLandscape; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
     bool allowWatchedFilter() { return true; }
 
 public slots:

--- a/libkodimote/videolibrary.cpp
+++ b/libkodimote/videolibrary.cpp
@@ -73,7 +73,7 @@ KodiModel *VideoLibrary::enterItem(int index)
     case 2:
         return new MusicVideos(false, this);
     case 3:
-        return new RecentItems(RecentItems::ModeVideo, RecentItems::RecentlyAdded, this);
+        return new RecentItems(MediaFormatVideo, RecentItems::RecentlyAdded, this);
     case 4:
         return new AddonSource(tr("Video Add-ons"), "video", "addons://sources/video", this);
     case 5:

--- a/libkodimote/videolibrary.h
+++ b/libkodimote/videolibrary.h
@@ -40,6 +40,7 @@ public:
     bool allowSearch();
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatNone; }
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
 
 public slots:
     void scanForContent();

--- a/libkodimote/videoplaylist.h
+++ b/libkodimote/videoplaylist.h
@@ -39,6 +39,8 @@ public:
     QString title() const;
     int playlistId() const;
 
+    MediaFormat mediaFormat() const { return MediaFormatVideo; }
+
 public slots:
     void refresh();
 


### PR DESCRIPTION
this allows displaying a default image by media type when there
is no thumbnail available from xbmc.

Also fixes a leak in imagecache.

Not sure how this applies to sailfish. In theory all you'd need to do is to add the changes in BrowserPage.qml, given sailfish has some artwork available to be used.