### PR TITLE
player: initialize m_timerActivated to false

### DIFF
--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -39,6 +39,7 @@ Player::Player(PlayerType type, QObject *parent) :
     m_lastPlaytimeUpdate(QDateTime::currentDateTime()),
     m_currentItem(new LibraryItem(this)),
     m_seeking(false),
+    m_timerActivated(false),
     m_shuffle(false),
     m_repeat(RepeatNone),
     m_currentSubtitle(-1),


### PR DESCRIPTION
Not initializing this variable may lead to random situations where the
timer is/starts running after starting playback (or when starting the
app when Kodi is playing something).

Fixes #53