### PR TITLE
Add support for resuming playback

### DIFF
--- a/apps/sailfish/qml/pages/BrowserPage.qml
+++ b/apps/sailfish/qml/pages/BrowserPage.qml
@@ -129,6 +129,20 @@ Page {
                 height: opened && listView.height * drawer._progress > contentItem.height ? listView.height * drawer._progress : contentItem.height
                 dock: Dock.Bottom
 
+                function playItem() {
+                    if (resume === 0) {
+                        browserPage.model.playItem(filterModel.mapToSourceIndex(index));
+                    } else {
+                        var dialog = pageStack.push("ResumeDialog.qml", {item: model});
+                        dialog.onAccepted.connect(function() {
+                            browserPage.model.playItem(filterModel.mapToSourceIndex(index), true);
+                        });
+                        dialog.onRejected.connect(function() {
+                            browserPage.model.playItem(filterModel.mapToSourceIndex(index));
+                        });
+                    }
+                }
+
                 background: Item {
                     anchors.fill: parent
                     width: drawer.width - 20
@@ -145,8 +159,7 @@ Page {
                             target: contentLoader.item
 
                             onPlayItem: {
-                                print("playItem()!")
-                                browserPage.model.playItem(filterModel.mapToSourceIndex(index))
+                                drawer.playItem();
                             }
 
                             onAddToPlaylist: {
@@ -189,20 +202,20 @@ Page {
                                     browserPage.home();
                                 });
                             } else {
-                                browserPage.model.playItem(filterModel.mapToSourceIndex(index));
+                                drawer.playItem();
                             }
                         }
                     }
 
                     Rectangle {
                         id: highlightBar
-                        color: Theme.highlightColor
+                        color: resume <= 0 ? Theme.highlightColor : Theme.secondaryHighlightColor
                         width: 8
                         anchors.top: thumbnailImage.top
                         anchors.bottom: thumbnailImage.bottom
                         anchors.right: thumbnailImage.left
                         anchors.rightMargin: 2
-                        visible: playcount === 0
+                        visible: playcount === 0 || resume > 0
                     }
 
                     Thumbnail {

--- a/apps/sailfish/qml/pages/ResumeDialog.qml
+++ b/apps/sailfish/qml/pages/ResumeDialog.qml
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014      Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                           *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+Dialog {
+    property variant item
+
+    DialogHeader {
+        id: header
+        acceptText: qsTr("Resume")
+    }
+
+    Label {
+        anchors { left: parent.left; right: parent.right; leftMargin: Theme.paddingLarge; rightMargin: Theme.paddingLarge; verticalCenter: parent.verticalCenter }
+        font.pixelSize: Theme.fontSizeExtraLarge
+        text: qsTr("Do you want to resume playback at %1?"). arg(item.resumeString)
+        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        horizontalAlignment: Text.AlignHCenter
+        color: Theme.highlightColor
+    }
+}

--- a/apps/sailfish/sailfish.pro
+++ b/apps/sailfish/sailfish.pro
@@ -52,5 +52,6 @@ OTHER_FILES += \
     qml/components/ChannelDetails.qml \
     qml/components/DockedControls.qml \
     qml/components/ControlsMenuItem.qml \
-    qml/pages/ProfileSelectionDialog.qml
+    qml/pages/ProfileSelectionDialog.qml \
+    qml/pages/ResumeDialog.qml
 

--- a/libkodimote/albums.cpp
+++ b/libkodimote/albums.cpp
@@ -181,9 +181,7 @@ void Albums::playItem(int index)
 {
     AudioPlaylistItem pItem;
     pItem.setAlbumId(m_list.at(index)->data(RoleAlbumId).toInt());
-    Kodi::instance()->audioPlayer()->playlist()->clear();
-    Kodi::instance()->audioPlayer()->playlist()->addItems(pItem);
-    Kodi::instance()->audioPlayer()->playItem(0);
+    Kodi::instance()->audioPlayer()->open(pItem);
 }
 
 void Albums::addToPlaylist(int index)

--- a/libkodimote/albums.cpp
+++ b/libkodimote/albums.cpp
@@ -177,11 +177,11 @@ KodiModel* Albums::enterItem(int index)
     return new Songs(m_artistId, m_list.at(index)->data(RoleAlbumId).toInt(), this);
 }
 
-void Albums::playItem(int index)
+void Albums::playItem(int index, bool resume)
 {
     AudioPlaylistItem pItem;
     pItem.setAlbumId(m_list.at(index)->data(RoleAlbumId).toInt());
-    Kodi::instance()->audioPlayer()->open(pItem);
+    Kodi::instance()->audioPlayer()->open(pItem, resume);
 }
 
 void Albums::addToPlaylist(int index)

--- a/libkodimote/albums.h
+++ b/libkodimote/albums.h
@@ -35,7 +35,7 @@ public:
     ~Albums();
 
     KodiModel* enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/artists.cpp
+++ b/libkodimote/artists.cpp
@@ -154,11 +154,11 @@ KodiModel *Artists::enterItem(int index)
     return new Albums(m_list.at(index)->data(RoleArtistId).toInt(), m_genreId, this);
 }
 
-void Artists::playItem(int index)
+void Artists::playItem(int index, bool resume)
 {
     AudioPlaylistItem pItem;
     pItem.setArtistId(m_list.at(index)->data(RoleArtistId).toInt());
-    Kodi::instance()->audioPlayer()->open(pItem);
+    Kodi::instance()->audioPlayer()->open(pItem, resume);
 }
 
 void Artists::addToPlaylist(int index)

--- a/libkodimote/artists.cpp
+++ b/libkodimote/artists.cpp
@@ -158,9 +158,7 @@ void Artists::playItem(int index)
 {
     AudioPlaylistItem pItem;
     pItem.setArtistId(m_list.at(index)->data(RoleArtistId).toInt());
-    Kodi::instance()->audioPlayer()->playlist()->clear();
-    Kodi::instance()->audioPlayer()->playlist()->addItems(pItem);
-    Kodi::instance()->audioPlayer()->playItem(0);
+    Kodi::instance()->audioPlayer()->open(pItem);
 }
 
 void Artists::addToPlaylist(int index)

--- a/libkodimote/artists.h
+++ b/libkodimote/artists.h
@@ -35,7 +35,7 @@ public:
     ~Artists();
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/audiolibrary.cpp
+++ b/libkodimote/audiolibrary.cpp
@@ -97,9 +97,10 @@ KodiModel *AudioLibrary::enterItem(int index)
     return 0;
 }
 
-void AudioLibrary::playItem(int index)
+void AudioLibrary::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     qDebug() << "cannot play whole audio library";
 }
 

--- a/libkodimote/audiolibrary.h
+++ b/libkodimote/audiolibrary.h
@@ -32,7 +32,7 @@ public:
     explicit AudioLibrary();
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/audioplayer.cpp
+++ b/libkodimote/audioplayer.cpp
@@ -40,11 +40,16 @@ Playlist * AudioPlayer::playlist() const
 
 void AudioPlayer::open(const PlaylistItem &item, bool resume)
 {
+    open(item, 0, resume);
+}
+
+void AudioPlayer::open(const PlaylistItem &item, int position, bool resume)
+{
     if (resume) {
         qDebug() << "resume is not supported for AudioPlayer";
     }
 
     m_playList->clear();
     m_playList->addItems(item);
-    playItem(0);
+    playItem(position);
 }

--- a/libkodimote/audioplayer.cpp
+++ b/libkodimote/audioplayer.cpp
@@ -38,8 +38,12 @@ Playlist * AudioPlayer::playlist() const
     return m_playList;
 }
 
-void AudioPlayer::open(const PlaylistItem &item)
+void AudioPlayer::open(const PlaylistItem &item, bool resume)
 {
+    if (resume) {
+        qDebug() << "resume is not supported for AudioPlayer";
+    }
+
     m_playList->clear();
     m_playList->addItems(item);
     playItem(0);

--- a/libkodimote/audioplayer.cpp
+++ b/libkodimote/audioplayer.cpp
@@ -37,3 +37,10 @@ Playlist * AudioPlayer::playlist() const
 {
     return m_playList;
 }
+
+void AudioPlayer::open(const PlaylistItem &item)
+{
+    m_playList->clear();
+    m_playList->addItems(item);
+    playItem(0);
+}

--- a/libkodimote/audioplayer.h
+++ b/libkodimote/audioplayer.h
@@ -33,7 +33,7 @@ public:
 
     Q_INVOKABLE virtual Playlist *playlist() const;
 
-    void open(const PlaylistItem &item);
+    void open(const PlaylistItem &item, bool resume = false);
 
 protected:
     virtual int playerId() const;

--- a/libkodimote/audioplayer.h
+++ b/libkodimote/audioplayer.h
@@ -34,6 +34,7 @@ public:
     Q_INVOKABLE virtual Playlist *playlist() const;
 
     void open(const PlaylistItem &item, bool resume = false);
+    void open(const PlaylistItem &item, int position, bool resume = false);
 
 protected:
     virtual int playerId() const;

--- a/libkodimote/audioplayer.h
+++ b/libkodimote/audioplayer.h
@@ -33,6 +33,8 @@ public:
 
     Q_INVOKABLE virtual Playlist *playlist() const;
 
+    void open(const PlaylistItem &item);
+
 protected:
     virtual int playerId() const;
 

--- a/libkodimote/channelgroups.cpp
+++ b/libkodimote/channelgroups.cpp
@@ -49,9 +49,10 @@ KodiModel *ChannelGroups::enterItem(int index)
     return new Channels(m_list.at(index)->data(RoleChannelGroupId).toInt(), this);
 }
 
-void ChannelGroups::playItem(int index)
+void ChannelGroups::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     qDebug() << "cannot play channelgroup";
 }
 

--- a/libkodimote/channelgroups.h
+++ b/libkodimote/channelgroups.h
@@ -32,7 +32,7 @@ public:
     QString title() const;
     void refresh();
     KodiModel* enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatNone; }

--- a/libkodimote/channels.cpp
+++ b/libkodimote/channels.cpp
@@ -59,13 +59,13 @@ KodiModel *Channels::enterItem(int index)
     return 0;
 }
 
-void Channels::playItem(int index)
+void Channels::playItem(int index, bool resume)
 {
     Q_UNUSED(index);
 
     VideoPlaylistItem item;
     item.setChannelId(m_list.at(index)->data(RoleChannelId).toInt());
-    Kodi::instance()->videoPlayer()->open(item);
+    Kodi::instance()->videoPlayer()->open(item, resume);
 }
 
 void Channels::addToPlaylist(int index)

--- a/libkodimote/channels.h
+++ b/libkodimote/channels.h
@@ -32,7 +32,7 @@ public:
     QString title() const;
     void refresh();
     KodiModel* enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     virtual QHash<int, QByteArray> roleNames() const;

--- a/libkodimote/episodes.cpp
+++ b/libkodimote/episodes.cpp
@@ -84,6 +84,7 @@ void Episodes::refresh()
     properties.append("thumbnail");
     properties.append("playcount");
     properties.append("file");
+    properties.append("resume");
     params.insert("properties", properties);
 
     if (m_tvshowid == KodiModel::ItemIdRecentlyAdded && m_seasonid == KodiModel::ItemIdRecentlyAdded) {
@@ -174,6 +175,7 @@ void Episodes::listReceived(const QVariantMap &rsp)
         item->setIgnoreArticle(false); // We ignore the setting here...
         item->setFileType("file");
         item->setPlayable(true);
+        item->setResume(itemMap.value("resume").toMap().value("position").toInt());
         list.append(item);
         m_idIndexMapping.insert(item->episodeId(), index++);
     }

--- a/libkodimote/episodes.cpp
+++ b/libkodimote/episodes.cpp
@@ -204,11 +204,11 @@ KodiModel *Episodes::enterItem(int index)
     return 0;
 }
 
-void Episodes::playItem(int index)
+void Episodes::playItem(int index, bool resume)
 {
     VideoPlaylistItem item;
     item.setEpisodeId(m_list.at(index)->data(RoleEpisodeId).toInt());
-    Kodi::instance()->videoPlayer()->open(item);
+    Kodi::instance()->videoPlayer()->open(item, resume);
 }
 
 void Episodes::addToPlaylist(int row)

--- a/libkodimote/episodes.cpp
+++ b/libkodimote/episodes.cpp
@@ -206,18 +206,14 @@ KodiModel *Episodes::enterItem(int index)
 
 void Episodes::playItem(int index)
 {
-    Kodi::instance()->videoPlayer()->playlist()->clear();
     VideoPlaylistItem item;
     item.setEpisodeId(m_list.at(index)->data(RoleEpisodeId).toInt());
-    Kodi::instance()->videoPlayer()->playlist()->addItems(item);
-    Kodi::instance()->videoPlayer()->playItem(0);
+    Kodi::instance()->videoPlayer()->open(item);
 }
 
 void Episodes::addToPlaylist(int row)
 {
     VideoPlaylistItem pItem;
-//    pItem.setTvShowId(m_tvshowid);
-//    pItem.setSeasonId(m_seasonid);
     pItem.setEpisodeId(index(row, 0, QModelIndex()).data(RoleEpisodeId).toInt());
     Kodi::instance()->videoPlayer()->playlist()->addItems(pItem);
 }

--- a/libkodimote/episodes.h
+++ b/libkodimote/episodes.h
@@ -33,7 +33,7 @@ public:
     explicit Episodes(int tvshowid = -1, int seasonid = -1, const QString &seasonString = QString(), KodiModel *parent = 0);
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/files.cpp
+++ b/libkodimote/files.cpp
@@ -109,7 +109,7 @@ KodiModel *Files::enterItem(int index)
     return 0;
 }
 
-void Files::playItem(int index)
+void Files::playItem(int index, bool resume)
 {
     if (m_mediaType == "picture") {
         m_player->stop();
@@ -123,7 +123,7 @@ void Files::playItem(int index)
     } else {
         pItem.setDirectory(item->fileName());
     }
-    m_player->open(pItem);
+    m_player->open(pItem, resume);
 }
 
 void Files::addToPlaylist(int index)

--- a/libkodimote/files.cpp
+++ b/libkodimote/files.cpp
@@ -117,23 +117,27 @@ void Files::playItem(int index)
     }
 
     LibraryItem *item = static_cast<LibraryItem*>(m_list.at(index));
+    PlaylistItem pItem;
     m_player->playlist()->clear();
     if(item->fileType() == "file") {
-        m_player->playlist()->addFile(item->fileName());
+        pItem.setFile(item->fileName());
     } else {
-        m_player->playlist()->addDirectory(item->fileName());
+        pItem.setDirectory(item->fileName());
     }
+    m_player->playlist()->addItems(pItem);
     m_player->playItem(0);
 }
 
 void Files::addToPlaylist(int index)
 {
     LibraryItem *item = static_cast<LibraryItem*>(m_list.at(index));
+    PlaylistItem pItem;
     if(item->fileType() == "file") {
-        m_player->playlist()->addFile(item->fileName());
+        pItem.setFile(item->fileName());
     } else {
-        m_player->playlist()->addDirectory(item->fileName());
+        pItem.setDirectory(item->fileName());
     }
+    m_player->playlist()->addItems(pItem);
 }
 
 QString Files::title() const

--- a/libkodimote/files.cpp
+++ b/libkodimote/files.cpp
@@ -118,14 +118,12 @@ void Files::playItem(int index)
 
     LibraryItem *item = static_cast<LibraryItem*>(m_list.at(index));
     PlaylistItem pItem;
-    m_player->playlist()->clear();
     if(item->fileType() == "file") {
         pItem.setFile(item->fileName());
     } else {
         pItem.setDirectory(item->fileName());
     }
-    m_player->playlist()->addItems(pItem);
-    m_player->playItem(0);
+    m_player->open(pItem);
 }
 
 void Files::addToPlaylist(int index)

--- a/libkodimote/files.h
+++ b/libkodimote/files.h
@@ -32,7 +32,7 @@ public:
     explicit Files(const QString &mediaType, const QString &dir, KodiModel *parent = 0);
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/files.h
+++ b/libkodimote/files.h
@@ -23,6 +23,8 @@
 
 #include "kodilibrary.h"
 
+class Player;
+
 class Files : public KodiLibrary
 {
     Q_OBJECT
@@ -46,6 +48,7 @@ protected:
     QString m_mediaType;
     QString m_dir;
     bool m_sort;
+    Player *m_player;
 
     virtual QString parseTitle(const QString &title) const;
     virtual bool filterFile(const QVariantMap &item) const;

--- a/libkodimote/genres.cpp
+++ b/libkodimote/genres.cpp
@@ -81,13 +81,10 @@ KodiModel *Genres::enterItem(int index)
     return new Artists(m_list.at(index)->data(RoleGenreId).toInt(), this);
 }
 
-void Genres::playItem(int index)
+void Genres::playItem(int index, bool resume)
 {
-//    AudioPlaylistItem pItem;
-//    pItem.setArtistId(m_list.at(index)->data(RoleArtistId).toInt());
-//    Kodi::instance()->audioPlayer()->playlist()->clear();
-//    Kodi::instance()->audioPlayer()->playlist()->addItems(pItem);
-//    Kodi::instance()->audioPlayer()->playItem(0);
+    Q_UNUSED(index)
+    Q_UNUSED(resume)
 }
 
 void Genres::addToPlaylist(int index)

--- a/libkodimote/genres.h
+++ b/libkodimote/genres.h
@@ -33,7 +33,7 @@ public:
     ~Genres();
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/kodilibrary.h
+++ b/libkodimote/kodilibrary.h
@@ -38,7 +38,7 @@ public:
     Q_INVOKABLE virtual KodiModel *enterItem(int index) = 0;
     Q_INVOKABLE virtual KodiModel *exit();
 
-    Q_INVOKABLE virtual void playItem(int index) = 0;
+    Q_INVOKABLE virtual void playItem(int index, bool resume = false) = 0;
     Q_INVOKABLE virtual void addToPlaylist(int index) = 0;
 
     Q_INVOKABLE QVariant get(int index, const QString &roleName);

--- a/libkodimote/kodimodel.cpp
+++ b/libkodimote/kodimodel.cpp
@@ -174,6 +174,8 @@ QHash<int, QByteArray> KodiModel::roleNames() const
     roleNames.insert(RoleCast, "cast");
     roleNames.insert(RolePlayingState, "playingState");
     roleNames.insert(RoleLockMode, "lockMode");
+    roleNames.insert(RoleResume, "resume");
+    roleNames.insert(RoleResumeString, "resumeString");
     return roleNames;
 }
 

--- a/libkodimote/kodimodel.h
+++ b/libkodimote/kodimodel.h
@@ -84,6 +84,8 @@ public:
         RoleComment,
         RolePlaycount,
         RoleCast,
+        RoleResume,
+        RoleResumeString,
         RolePlayingState,
         RoleLockMode
     };

--- a/libkodimote/libraryitem.cpp
+++ b/libkodimote/libraryitem.cpp
@@ -75,6 +75,7 @@ void LibraryItem::init()
     m_comment = QString();
     m_playcount = -1;
     m_cast = QString();
+    m_resume = 0;
 
 }
 
@@ -168,6 +169,10 @@ QVariant LibraryItem::data(int role) const
         return m_playcount;
     case KodiModel::RoleCast:
         return m_cast;
+    case KodiModel::RoleResume:
+        return m_resume;
+    case KodiModel::RoleResumeString:
+        return resumeString();
     }
 
     return KodiModelItem::data(role);
@@ -666,6 +671,27 @@ void LibraryItem::setCast(const QString &cast)
 {
     m_cast = cast;
     emit castChanged();
+}
+
+int LibraryItem::resume() const
+{
+    return m_resume;
+}
+
+QString LibraryItem::resumeString() const
+{
+    QTime time = QTime(0, 0, 0).addSecs(m_resume);
+    if (m_duration.hour() > 0) {
+        return time.toString("hh:mm:ss");
+    } else {
+        return time.toString("mm:ss");
+    }
+}
+
+void LibraryItem::setResume(int resume)
+{
+    m_resume = resume;
+    emit resumeChanged();
 }
 
 void LibraryItem::imageFetched(int id)

--- a/libkodimote/libraryitem.h
+++ b/libkodimote/libraryitem.h
@@ -76,6 +76,8 @@ class LibraryItem : public KodiModelItem
     Q_PROPERTY(QString comment READ comment WRITE setComment NOTIFY commentChanged)
     Q_PROPERTY(int playcount READ playcount WRITE setPlaycount NOTIFY playcountChanged)
     Q_PROPERTY(QString cast READ cast WRITE setCast NOTIFY castChanged)
+    Q_PROPERTY(int resume READ resume WRITE setResume NOTIFY resumeChanged)
+    Q_PROPERTY(QString resumeString READ resumeString NOTIFY resumeChanged)
 
 public:
     explicit LibraryItem(const QString &title, const QString &subTitle = QString(), QObject *parent = 0);
@@ -212,6 +214,10 @@ public:
     QString cast() const;
     void setCast(const QString &cast);
 
+    int resume() const;
+    QString resumeString() const;
+    void setResume(int resume);
+
     virtual QVariant data(int role) const;
 
 signals:
@@ -258,6 +264,7 @@ signals:
     void commentChanged();
     void playcountChanged();
     void castChanged();
+    void resumeChanged();
 
 private slots:
     Q_INVOKABLE void imageFetched(int id);
@@ -309,6 +316,7 @@ private:
     QString m_comment;
     int m_playcount;
     QString m_cast;
+    int m_resume;
 
     enum ImageType {
         ImageTypeThumbnail,

--- a/libkodimote/movies.cpp
+++ b/libkodimote/movies.cpp
@@ -214,10 +214,10 @@ KodiModel *Movies::enterItem(int index)
     return 0;
 }
 
-void Movies::playItem(int index)
+void Movies::playItem(int index, bool resume)
 {
     VideoPlaylistItem item(m_list.at(index)->data(RoleMovieId).toInt());
-    Kodi::instance()->videoPlayer()->open(item);
+    Kodi::instance()->videoPlayer()->open(item, resume);
 }
 
 void Movies::addToPlaylist(int row)

--- a/libkodimote/movies.cpp
+++ b/libkodimote/movies.cpp
@@ -81,6 +81,7 @@ void Movies::refresh()
     properties.append("file");
     properties.append("genre");
     properties.append("year");
+    properties.append("resume");
     params.insert("properties", properties);
 
 
@@ -180,6 +181,7 @@ void Movies::listReceived(const QVariantMap &rsp)
         item->setIgnoreArticle(ignoreArticle());
         item->setFileType("file");
         item->setPlayable(true);
+        item->setResume(itemMap.value("resume").toMap().value("position").toInt());
         list.append(item);
         m_idIndexMapping.insert(item->movieId(), index++);
     }

--- a/libkodimote/movies.cpp
+++ b/libkodimote/movies.cpp
@@ -216,10 +216,8 @@ KodiModel *Movies::enterItem(int index)
 
 void Movies::playItem(int index)
 {
-    Kodi::instance()->videoPlayer()->playlist()->clear();
     VideoPlaylistItem item(m_list.at(index)->data(RoleMovieId).toInt());
-    Kodi::instance()->videoPlayer()->playlist()->addItems(item);
-    Kodi::instance()->videoPlayer()->playItem(0);
+    Kodi::instance()->videoPlayer()->open(item);
 }
 
 void Movies::addToPlaylist(int row)

--- a/libkodimote/movies.h
+++ b/libkodimote/movies.h
@@ -33,7 +33,7 @@ public:
     ~Movies();
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/musicvideos.cpp
+++ b/libkodimote/musicvideos.cpp
@@ -170,12 +170,9 @@ KodiModel *MusicVideos::enterItem(int index)
 
 void MusicVideos::playItem(int index)
 {
-    qDebug() << "should play item" << index << "musicvideoid is" << m_list.at(index)->data(RoleMusicVideoId).toInt();
-    Kodi::instance()->videoPlayer()->playlist()->clear();
     VideoPlaylistItem item;
     item.setMusicVideoId(m_list.at(index)->data(RoleMusicVideoId).toInt());
-    Kodi::instance()->videoPlayer()->playlist()->addItems(item);
-    Kodi::instance()->videoPlayer()->playItem(0);
+    Kodi::instance()->videoPlayer()->open(item);
 }
 
 void MusicVideos::addToPlaylist(int row)

--- a/libkodimote/musicvideos.cpp
+++ b/libkodimote/musicvideos.cpp
@@ -73,6 +73,7 @@ void MusicVideos::refresh()
     properties.append("fanart");
     properties.append("playcount");
     properties.append("year");
+    properties.append("resume");
     params.insert("properties", properties);
 
 
@@ -138,6 +139,7 @@ void MusicVideos::listReceived(const QVariantMap &rsp)
         item->setFileType("file");
         item->setPlayable(true);
         item->setYear(itemMap.value("year").toString());
+        item->setResume(itemMap.value("resume").toMap().value("position").toInt());
         list.append(item);
         m_idIndexMapping.insert(item->musicvideoId(), index++);
     }

--- a/libkodimote/musicvideos.cpp
+++ b/libkodimote/musicvideos.cpp
@@ -168,11 +168,11 @@ KodiModel *MusicVideos::enterItem(int index)
     return 0;
 }
 
-void MusicVideos::playItem(int index)
+void MusicVideos::playItem(int index, bool resume)
 {
     VideoPlaylistItem item;
     item.setMusicVideoId(m_list.at(index)->data(RoleMusicVideoId).toInt());
-    Kodi::instance()->videoPlayer()->open(item);
+    Kodi::instance()->videoPlayer()->open(item, resume);
 }
 
 void MusicVideos::addToPlaylist(int row)

--- a/libkodimote/musicvideos.h
+++ b/libkodimote/musicvideos.h
@@ -32,7 +32,7 @@ public:
     explicit MusicVideos(bool recentlyAdded, KodiModel *parent = 0);
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -535,10 +535,12 @@ void Player::playItem(int index)
     KodiConnection::sendCommand("Player.Open", params);
 }
 
-void Player::open(const PlaylistItem &item)
+void Player::open(const PlaylistItem &item, bool resume)
 {
     QVariantMap params;
     params.insert("item", item.toMap());
+    QVariantMap options;
+    options.insert("resume", resume);
     params.insert("options", options);
     KodiConnection::sendCommand("Player.Open", params);
 }

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -535,6 +535,14 @@ void Player::playItem(int index)
     KodiConnection::sendCommand("Player.Open", params);
 }
 
+void Player::open(const PlaylistItem &item)
+{
+    QVariantMap params;
+    params.insert("item", item.toMap());
+    params.insert("options", options);
+    KodiConnection::sendCommand("Player.Open", params);
+}
+
 bool Player::shuffle() const
 {
     return m_shuffle;

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -87,7 +87,7 @@ public:
 
     /// play the given item from the playlist
     Q_INVOKABLE void playItem(int index);
-    virtual void open(const PlaylistItem &item);
+    virtual void open(const PlaylistItem &item, bool resume = false);
 
     bool shuffle() const;
     void setShuffle(bool shuffle);

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -28,6 +28,7 @@
 #include <QStringList>
 
 class Playlist;
+class PlaylistItem;
 class LibraryItem;
 
 class Player : public QObject
@@ -86,6 +87,7 @@ public:
 
     /// play the given item from the playlist
     Q_INVOKABLE void playItem(int index);
+    virtual void open(const PlaylistItem &item);
 
     bool shuffle() const;
     void setShuffle(bool shuffle);

--- a/libkodimote/playlist.cpp
+++ b/libkodimote/playlist.cpp
@@ -66,45 +66,6 @@ void Playlist::clear()
     refresh();
 }
 
-void Playlist::addPlaylist(const QString &playlist)
-{
-    PlaylistItem pItem;
-    pItem.setPlayList(playlist);
-
-    QVariantMap params;
-    params.insert("item", pItem.toMap());
-    params.insert("playlistid", playlistId());
-
-    KodiConnection::sendCommand("Playlist.Add", params);
-    refresh();
-}
-
-void Playlist::addFile(const QString &file)
-{
-    PlaylistItem pItem;
-    pItem.setFile(file);
-
-    QVariantMap params;
-    params.insert("item", pItem.toMap());
-    params.insert("playlistid", playlistId());
-
-    KodiConnection::sendCommand("Playlist.Add", params);
-    refresh();
-}
-
-void Playlist::addDirectory(const QString &dir)
-{
-    PlaylistItem pItem;
-    pItem.setDirectory(dir);
-
-    QVariantMap params;
-    params.insert("item", pItem.toMap());
-    params.insert("playlistid", playlistId());
-
-    KodiConnection::sendCommand("Playlist.Add", params);
-    refresh();
-}
-
 void Playlist::receivedAnnouncement(const QVariantMap &map)
 {
     Q_UNUSED(map)

--- a/libkodimote/playlist.h
+++ b/libkodimote/playlist.h
@@ -43,9 +43,6 @@ public:
 
     Q_INVOKABLE virtual void clear();
     virtual void addItems(const PlaylistItem &item);
-    void addPlaylist(const QString &playlistId);
-    void addFile(const QString &file);
-    void addDirectory(const QString &dir);
     Q_INVOKABLE void removeItem(int index);
 
     int count() const;

--- a/libkodimote/pvrmenu.cpp
+++ b/libkodimote/pvrmenu.cpp
@@ -57,9 +57,10 @@ KodiModel *PvrMenu::enterItem(int index)
     return 0;
 }
 
-void PvrMenu::playItem(int index)
+void PvrMenu::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     qDebug() << "cannot play PVR Menu";
 }
 

--- a/libkodimote/pvrmenu.h
+++ b/libkodimote/pvrmenu.h
@@ -31,7 +31,7 @@ public:
     
     QString title() const;
     KodiModel* enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     ThumbnailFormat thumbnailFormat() const { return ThumbnailFormatNone; }

--- a/libkodimote/recentitems.cpp
+++ b/libkodimote/recentitems.cpp
@@ -88,9 +88,10 @@ KodiModel *RecentItems::enterItem(int index)
     return 0;
 }
 
-void RecentItems::playItem(int index)
+void RecentItems::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     qDebug() << "cannot play whole recently added items";
 }
 

--- a/libkodimote/recentitems.h
+++ b/libkodimote/recentitems.h
@@ -41,7 +41,7 @@ public:
     explicit RecentItems(Mode mode, RecentlyWhat what, KodiLibrary *parent);
     
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/recordings.cpp
+++ b/libkodimote/recordings.cpp
@@ -96,7 +96,9 @@ void Recordings::playItem(int index)
 //    item.setRecordingId(m_list.at(index)->data(RoleRecordingId).toInt());
 //    Kodi::instance()->videoPlayer()->playlist()->addItems(item);
 
-    Kodi::instance()->videoPlayer()->playlist()->addFile(m_list.at(index)->data(RoleFileName).toString());
+    PlaylistItem pItem;
+    pItem.setFile(m_list.at(index)->data(RoleFileName).toString());
+    Kodi::instance()->videoPlayer()->playlist()->addItems(pItem);
 
     Kodi::instance()->videoPlayer()->playItem(0);
 }

--- a/libkodimote/recordings.cpp
+++ b/libkodimote/recordings.cpp
@@ -88,19 +88,10 @@ KodiModel *Recordings::enterItem(int index)
 
 void Recordings::playItem(int index)
 {
-    Kodi::instance()->videoPlayer()->playlist()->clear();
+    VideoPlaylistItem item;
+    item.setRecordingId(m_list.at(index)->data(RoleRecordingId).toInt());
 
-    // FIXME: Playlist.Add() doesn't seem to support recordingid yet. We need to use the file mechanism for now.
-//    VideoPlaylistItem item;
-//    qDebug() << "setting recid" << m_list.at(index)->data(RoleRecordingId).toInt();
-//    item.setRecordingId(m_list.at(index)->data(RoleRecordingId).toInt());
-//    Kodi::instance()->videoPlayer()->playlist()->addItems(item);
-
-    PlaylistItem pItem;
-    pItem.setFile(m_list.at(index)->data(RoleFileName).toString());
-    Kodi::instance()->videoPlayer()->playlist()->addItems(pItem);
-
-    Kodi::instance()->videoPlayer()->playItem(0);
+    Kodi::instance()->videoPlayer()->open(item);
 }
 
 void Recordings::addToPlaylist(int index)

--- a/libkodimote/recordings.cpp
+++ b/libkodimote/recordings.cpp
@@ -86,12 +86,12 @@ KodiModel *Recordings::enterItem(int index)
 
 }
 
-void Recordings::playItem(int index)
+void Recordings::playItem(int index, bool resume)
 {
     VideoPlaylistItem item;
     item.setRecordingId(m_list.at(index)->data(RoleRecordingId).toInt());
 
-    Kodi::instance()->videoPlayer()->open(item);
+    Kodi::instance()->videoPlayer()->open(item, resume);
 }
 
 void Recordings::addToPlaylist(int index)

--- a/libkodimote/recordings.h
+++ b/libkodimote/recordings.h
@@ -32,7 +32,7 @@ public:
     QString title() const;
     void refresh();
     KodiModel* enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     virtual QHash<int, QByteArray> roleNames() const;

--- a/libkodimote/seasons.cpp
+++ b/libkodimote/seasons.cpp
@@ -156,9 +156,10 @@ KodiModel *Seasons::enterItem(int index)
     return new Episodes(m_tvshowid, m_list.at(index)->data(RoleSeason).toInt(), m_list.at(index)->title(), this);
 }
 
-void Seasons::playItem(int index)
+void Seasons::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     qDebug() << "Seasons: playing whole season not supported by kodi";
 }
 

--- a/libkodimote/seasons.h
+++ b/libkodimote/seasons.h
@@ -32,7 +32,7 @@ public:
     explicit Seasons(int tvhsowId = -1, KodiModel *parent = 0);
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/shares.cpp
+++ b/libkodimote/shares.cpp
@@ -99,9 +99,10 @@ KodiModel *Shares::enterItem(int index)
     return new Files(m_mediaType, m_list.at(index)->data(RoleFileName).toString(), this);
 }
 
-void Shares::playItem(int index)
+void Shares::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     koDebug(XDAREA_FILES) << "Playing whole shares is not supported";
 }
 

--- a/libkodimote/shares.h
+++ b/libkodimote/shares.h
@@ -30,7 +30,7 @@ public:
     explicit Shares(const QString &mediatype, KodiLibrary *parent = 0);
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/songs.cpp
+++ b/libkodimote/songs.cpp
@@ -200,7 +200,7 @@ KodiModel* Songs::enterItem(int index)
     return 0;
 }
 
-void Songs::playItem(int row)
+void Songs::playItem(int row, bool resume)
 {
     AudioPlaylistItem pItem;
     if(m_artistId < 0 && m_albumId < 0) {
@@ -210,9 +210,7 @@ void Songs::playItem(int row)
     } else {
         pItem.setAlbumId(m_albumId);
     }
-    Kodi::instance()->audioPlayer()->playlist()->clear();
-    Kodi::instance()->audioPlayer()->playlist()->addItems(pItem);
-    Kodi::instance()->audioPlayer()->playItem(row);
+    Kodi::instance()->audioPlayer()->open(pItem, resume);
 }
 
 void Songs::addToPlaylist(int row)

--- a/libkodimote/songs.cpp
+++ b/libkodimote/songs.cpp
@@ -212,7 +212,6 @@ void Songs::playItem(int row)
     }
     Kodi::instance()->audioPlayer()->playlist()->clear();
     Kodi::instance()->audioPlayer()->playlist()->addItems(pItem);
-//    Kodi::instance()->audioPlayer()->playlist()->playItem(row);
     Kodi::instance()->audioPlayer()->playItem(row);
 }
 

--- a/libkodimote/songs.cpp
+++ b/libkodimote/songs.cpp
@@ -210,7 +210,7 @@ void Songs::playItem(int row, bool resume)
     } else {
         pItem.setAlbumId(m_albumId);
     }
-    Kodi::instance()->audioPlayer()->open(pItem, resume);
+    Kodi::instance()->audioPlayer()->open(pItem, row, resume);
 }
 
 void Songs::addToPlaylist(int row)

--- a/libkodimote/songs.h
+++ b/libkodimote/songs.h
@@ -33,7 +33,7 @@ public:
     ~Songs();
 
     KodiModel* enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/tvshows.cpp
+++ b/libkodimote/tvshows.cpp
@@ -185,9 +185,10 @@ KodiModel *TvShows::enterItem(int index)
     return new Seasons(m_list.at(index)->data(RoleTvShowId).toInt(), this);
 }
 
-void TvShows::playItem(int index)
+void TvShows::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     qDebug() << "TvShows: playing whole tvshow not supported by kodi";
 }
 

--- a/libkodimote/tvshows.h
+++ b/libkodimote/tvshows.h
@@ -33,7 +33,7 @@ public:
     ~TvShows();
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/videolibrary.cpp
+++ b/libkodimote/videolibrary.cpp
@@ -82,9 +82,10 @@ KodiModel *VideoLibrary::enterItem(int index)
     return 0;
 }
 
-void VideoLibrary::playItem(int index)
+void VideoLibrary::playItem(int index, bool resume)
 {
     Q_UNUSED(index)
+    Q_UNUSED(resume)
     qDebug() << "cannot play whole video library";
 }
 

--- a/libkodimote/videolibrary.h
+++ b/libkodimote/videolibrary.h
@@ -32,7 +32,7 @@ public:
     explicit VideoLibrary(KodiModel *parent = 0);
 
     KodiModel *enterItem(int index);
-    void playItem(int index);
+    void playItem(int index, bool resume = false);
     void addToPlaylist(int index);
 
     QString title() const;

--- a/libkodimote/videoplayer.cpp
+++ b/libkodimote/videoplayer.cpp
@@ -39,10 +39,3 @@ Playlist *VideoPlayer::playlist() const
     return m_playlist;
 }
 
-void VideoPlayer::open(const VideoPlaylistItem &item)
-{
-    QVariantMap params;
-    params.insert("item", item.toMap());
-    KodiConnection::sendCommand("Player.Open", params);
-}
-

--- a/libkodimote/videoplayer.h
+++ b/libkodimote/videoplayer.h
@@ -22,7 +22,6 @@
 #define VIDEOPLAYER_H
 
 #include "player.h"
-#include "videoplaylistitem.h"
 
 class VideoPlaylist;
 
@@ -33,8 +32,6 @@ public:
     VideoPlayer(QObject *parent = 0);
 
     virtual Playlist *playlist() const;
-
-    void open(const VideoPlaylistItem &item);
 
 protected:
     virtual int playerId() const;


### PR DESCRIPTION
Fixes #14 

- [x] lib: support resuming playback
- [x] lib: support reading resume point
- [x] sailfish: highlight resumable items
- [x] sailfish: ask to resume resumable items
- [x] ubuntu: highlight resumable items
- [ ] ubuntu: ask to resume resumable items

@mzanetti can you add support in Ubuntu? Shouldn't be too hard, but as it requires a new page/dialog etc I can't just change a few lines of code