### PR TITLE
Player timing improvements

### DIFF
--- a/apps/sailfish/qml/pages/NowPlayingPage.qml
+++ b/apps/sailfish/qml/pages/NowPlayingPage.qml
@@ -254,7 +254,7 @@ Page {
                             anchors.bottom: parent.bottom
                             color: Theme.highlightColor
                             font.pixelSize: Theme.fontSizeExtraSmall
-                            text: currentItem ? currentItem.durationString : "00:00"
+                            text: player.totalTimeString
                         }
 
                         Rectangle {
@@ -296,25 +296,7 @@ Page {
                                 // Center label on mouseX
                                 progressBarLabel.x = mouseX - progressBarLabel.width / 2;
 
-                                // Calculate time under mouseX
-                                var progressedWidth = mouseX - progressBar.x;
-                                var targetTime = progressedWidth * currentItem.durationInSecs / progressBar.width;
-                                targetTime = Math.min(targetTime, currentItem.durationInSecs);
-                                targetTime = Math.max(targetTime, 0);
-
-                                // Translate to human readable time
-                                var hours = Math.floor(targetTime / 60 / 60);
-                                var minutes = Math.floor(targetTime / 60) % 60;
-                                if(minutes < 10) minutes = "0" + minutes;
-                                var seconds = Math.floor(targetTime) % 60;
-                                if(seconds < 10) seconds = "0" + seconds;
-
-                                // Write into the label
-                                if(currentItem.durationInSecs < 60 * 60) {
-                                    progressBarLabelText.text = minutes + ":" + seconds;
-                                } else {
-                                    progressBarLabelText.text = hours + ":" + minutes + ":" + seconds;
-                                }
+                                progressBarLabelText.text = player.calculateTimeString(mouseX * 100 / width);
                             }
 
                             onReleased: {

--- a/apps/ubuntu/qml/NowPlayingPage.qml
+++ b/apps/ubuntu/qml/NowPlayingPage.qml
@@ -284,28 +284,8 @@ KodiPage {
                             // Center label on mouseX
                             progressBarLabel.x = mouseX - progressBarLabel.width / 2;
 
-                            // Calculate time under mouseX
-                            var progressedWidth = mouseX - progressBar.x;
-                            var targetTime = progressedWidth * currentItem.durationInSecs / progressBar.width;
-                            targetTime = Math.min(targetTime, currentItem.durationInSecs);
-                            targetTime = Math.max(targetTime, 0);
-                            print("currentItem", currentItem.durationInSecs)
-
-                            // Translate to human readable time
-                            var hours = Math.floor(targetTime / 60 / 60);
-                            var minutes = Math.floor(targetTime / 60) % 60;
-                            if(minutes < 10) minutes = "0" + minutes;
-                            var seconds = Math.floor(targetTime) % 60;
-                            if(seconds < 10) seconds = "0" + seconds;
-
-                            // Write into the label
-                            if(currentItem.durationInSecs < 60 * 60) {
-                                progressBarLabelText.text = minutes + ":" + seconds;
-                            } else {
-                                progressBarLabelText.text = hours + ":" + minutes + ":" + seconds;
-                            }
+                            progressBarLabelText.text = player.calculateTimeString(mouseX * 100 / width);
                             mouse.accepted = true
-                            print("mouse accepted")
                         }
                         onReleased: {
                             player.seek(mouseX * 100 / width)
@@ -323,7 +303,7 @@ KodiPage {
                     }
 
                     Label {
-                        text: currentItem ? currentItem.durationString : "00:00"
+                        text: player.totalTimeString
                         horizontalAlignment: Text.AlignRight
                         width: (parent.width - parent.spacing) / 2
                     }

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -444,11 +444,7 @@ QTime Player::totalTime() const
 
 QString Player::totalTimeString() const
 {
-    if (m_totalTime.hour() > 0) {
-        return m_totalTime.toString("hh:mm:ss");
-    } else {
-        return m_totalTime.toString("mm:ss");
-    }
+    return formatTime(m_totalTime);
 }
 
 void Player::updatePlaytime()
@@ -647,8 +643,22 @@ QTime Player::parseTime(const QVariantMap &timeMap) const
     return time;
 }
 
+QString Player::formatTime(const QTime &time) const
+{
+    if (time.hour() > 0) {
+        return time.toString("hh:mm:ss");
+    } else {
+        return time.toString("mm:ss");
+    }
+}
+
 QTime Player::calculateTime(double percentage) const
 {
     int milliSeconds = QTime(0, 0, 0).msecsTo(m_totalTime) * percentage / 100;
     return QTime(0, 0, 0).addMSecs(milliSeconds);
+}
+
+QString Player::calculateTimeString(double percentage) const
+{
+    return formatTime(calculateTime(percentage));
 }

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -613,12 +613,18 @@ void Player::setTimerActive(bool active)
 
 void Player::seek(double percentage)
 {
-    if(m_seeking && percentage != m_percentage) {
+    if(m_seeking) {
         return;
     }
+
+    QTime position = calculateTime(percentage);
     QVariantMap params;
     params.insert("playerid", playerId());
-    params.insert("value", percentage);
+    QVariantMap time;
+    time.insert("hours", position.hour());
+    time.insert("minutes", position.minute());
+    time.insert("seconds", position.second());
+    params.insert("value", time);
 
     m_seeking = true;
     KodiConnection::sendCommand("Player.Seek", params);
@@ -639,4 +645,10 @@ QTime Player::parseTime(const QVariantMap &timeMap) const
     time.setHMS(hours, minutes, seconds, mseconds);
 
     return time;
+}
+
+QTime Player::calculateTime(double percentage) const
+{
+    int milliSeconds = QTime(0, 0, 0).msecsTo(m_totalTime) * percentage / 100;
+    return QTime(0, 0, 0).addMSecs(milliSeconds);
 }

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -111,6 +111,8 @@ public:
 
     LibraryItem* currentItem() const;
 
+    QTime calculateTime(double percentage) const;
+
 signals:
     void stateChanged();
     void speedChanged();

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -42,6 +42,8 @@ class Player : public QObject
     Q_PROPERTY(int speed READ speed NOTIFY speedChanged)
     Q_PROPERTY(double percentage READ percentage NOTIFY percentageChanged)
     Q_PROPERTY(QString time READ time NOTIFY timeChanged)
+    Q_PROPERTY(QTime totalTime READ totalTime NOTIFY currentItemChanged)
+    Q_PROPERTY(QString totalTimeString READ totalTimeString NOTIFY currentItemChanged)
     Q_PROPERTY(bool timerActive READ timerActive WRITE setTimerActive)
     Q_PROPERTY(bool shuffle READ shuffle WRITE setShuffle NOTIFY shuffleChanged)
     Q_PROPERTY(Repeat repeat READ repeat WRITE setRepeat NOTIFY repeatChanged)
@@ -74,6 +76,8 @@ public:
     int speed() const;
     double percentage() const;
     QString time() const;
+    QTime totalTime() const;
+    QString totalTimeString() const;
 
     void refresh();
     void detach();
@@ -150,7 +154,8 @@ private slots:
     void mediaPropsReceived(const QVariantMap &rsp);
 
 private:
-    void updatePlaytime(const QVariantMap &time);
+    void updatePlaytime(const QVariantMap &timeMap);
+    QTime parseTime(const QVariantMap &timeMap) const;
 
 protected:
     PlayerType m_type;
@@ -163,6 +168,7 @@ protected:
     LibraryItem* m_currentItem;
     bool m_seeking;
     bool m_timerActivated;
+    QTime m_totalTime;
 
     bool m_shuffle;
     Repeat m_repeat;

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -112,6 +112,7 @@ public:
     LibraryItem* currentItem() const;
 
     QTime calculateTime(double percentage) const;
+    Q_INVOKABLE QString calculateTimeString(double percentage) const;
 
 signals:
     void stateChanged();
@@ -152,6 +153,7 @@ private slots:
 private:
     void updatePlaytime(const QVariantMap &timeMap);
     QTime parseTime(const QVariantMap &timeMap) const;
+    QString formatTime(const QTime &time) const;
 
 protected:
     PlayerType m_type;

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -79,7 +79,6 @@ public:
     QTime totalTime() const;
     QString totalTimeString() const;
 
-    void refresh();
     void detach();
 
     PlayerType type() const;
@@ -133,11 +132,9 @@ public slots:
     void skipNext();
     void seekBackward();
     void seekForward();
+    void refresh();
 
 private slots:
-    void getSpeed();
-    void getPlaytime();
-    void getPosition();
     void receivedAnnouncement(const QVariantMap& map);
     void updatePlaytime();
     void getRepeatShuffle();
@@ -145,9 +142,6 @@ private slots:
 
     void getCurrentItemDetails();
 
-    void speedReceived(const QVariantMap &rsp);
-    void playtimeReceived(const QVariantMap &rsp);
-    void positionReceived(const QVariantMap &rsp);
     void repeatShuffleReceived(const QVariantMap &rsp);
     void detailsReceived(const QVariantMap &rsp);
     void refreshReceived(const QVariantMap &rsp);


### PR DESCRIPTION
Fixes #55.

Use Player totaltime instead of duration of current item, as duration is based on scraper info and may be incorrect, while totaltime is always correct. Also changed `Player.Seek` call to send times (instead of percentages) and moved percentage to time calculation from QML to C++.

@mzanetti Ubuntu is updated, but untested