### PR TITLE
Add support for MPRIS2 DBus spec

### DIFF
--- a/apps/sailfish/qml/pages/NowPlayingPage.qml
+++ b/apps/sailfish/qml/pages/NowPlayingPage.qml
@@ -246,7 +246,7 @@ Page {
                             anchors.bottom: parent.bottom
                             color: Theme.highlightColor
                             font.pixelSize: Theme.fontSizeExtraSmall
-                            text: player ? player.time : "00:00"
+                            text: player ? player.timeString : "00:00"
                         }
 
                         Label {

--- a/apps/sailfish/src/main.cpp
+++ b/apps/sailfish/src/main.cpp
@@ -64,17 +64,17 @@ int main(int argc, char *argv[])
 
     Kodi::instance()->setDataPath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
 
+    QQuickView *view = SailfishApp::createView();
+
     Settings settings;
 
-    SailfishHelper helper(&settings);
-    Q_UNUSED(helper)
+    SailfishHelper helper(view, &settings);
 
     ProtocolManager protocols;
 
-    MprisController controller(&protocols);
+    MprisController controller(&protocols, &helper);
     Q_UNUSED(controller)
 
-    QQuickView *view = SailfishApp::createView();
     view->engine()->setNetworkAccessManagerFactory(new NetworkAccessManagerFactory());
     view->engine()->rootContext()->setContextProperty("kodi", Kodi::instance());
     view->engine()->rootContext()->setContextProperty("settings", &settings);

--- a/apps/sailfish/src/main.cpp
+++ b/apps/sailfish/src/main.cpp
@@ -69,7 +69,9 @@ int main(int argc, char *argv[])
     SailfishHelper helper(&settings);
     Q_UNUSED(helper)
 
-    MprisController controller;
+    ProtocolManager protocols;
+
+    MprisController controller(&protocols);
     Q_UNUSED(controller)
 
     QQuickView *view = SailfishApp::createView();

--- a/apps/sailfish/src/main.cpp
+++ b/apps/sailfish/src/main.cpp
@@ -32,6 +32,7 @@
 #include "libkodimote/eventclient.h"
 #include "libkodimote/settings.h"
 #include "libkodimote/networkaccessmanagerfactory.h"
+#include "libkodimote/mpris2/mpriscontroller.h"
 #include "sailfishhelper.h"
 
 #include <sailfishapp.h>
@@ -67,6 +68,9 @@ int main(int argc, char *argv[])
 
     SailfishHelper helper(&settings);
     Q_UNUSED(helper)
+
+    MprisController controller;
+    Q_UNUSED(controller)
 
     QQuickView *view = SailfishApp::createView();
     view->engine()->setNetworkAccessManagerFactory(new NetworkAccessManagerFactory());

--- a/apps/sailfish/src/sailfishhelper.cpp
+++ b/apps/sailfish/src/sailfishhelper.cpp
@@ -40,8 +40,9 @@
 using namespace QtContacts;
 #endif
 
-SailfishHelper::SailfishHelper(Settings *settings, QObject *parent) :
+SailfishHelper::SailfishHelper(QQuickView *quickView, Settings *settings, QObject *parent) :
     PlatformHelper(settings, parent),
+    m_quickView(quickView),
     m_resourceSet(new ResourcePolicy::ResourceSet("player", 0, false, true))
 {
     m_resourceSet->addResourceObject(new ResourcePolicy::ScaleButtonResource);
@@ -52,6 +53,16 @@ SailfishHelper::SailfishHelper(Settings *settings, QObject *parent) :
     QDBusConnection systemBus = QDBusConnection::systemBus();
     systemBus.connect("org.ofono", "/ril_0", "org.ofono.VoiceCallManager", "CallAdded", this, SLOT(callAdded(QDBusMessage)));
     systemBus.connect("org.ofono", "/ril_0", "org.ofono.VoiceCallManager", "CallRemoved", this, SLOT(callEnded()));
+}
+
+bool SailfishHelper::canRaise() const
+{
+    return true;
+}
+
+void SailfishHelper::raise()
+{
+    m_quickView->raise();
 }
 
 bool SailfishHelper::eventFilter(QObject *obj, QEvent *event)

--- a/apps/sailfish/src/sailfishhelper.cpp
+++ b/apps/sailfish/src/sailfishhelper.cpp
@@ -34,8 +34,6 @@
 #include "sailfishhelper.h"
 #include "libkodimote/kodi.h"
 #include "libkodimote/kodihostmodel.h"
-#include "libkodimote/videoplayer.h"
-#include "libkodimote/audioplayer.h"
 #include "libkodimote/settings.h"
 
 #ifndef HARBOUR_BUILD
@@ -43,8 +41,7 @@ using namespace QtContacts;
 #endif
 
 SailfishHelper::SailfishHelper(Settings *settings, QObject *parent) :
-    QObject(parent),
-    m_settings(settings),
+    PlatformHelper(settings, parent),
     m_resourceSet(new ResourcePolicy::ResourceSet("player", 0, false, true))
 {
     m_resourceSet->addResourceObject(new ResourcePolicy::ScaleButtonResource);
@@ -54,7 +51,7 @@ SailfishHelper::SailfishHelper(Settings *settings, QObject *parent) :
 
     QDBusConnection systemBus = QDBusConnection::systemBus();
     systemBus.connect("org.ofono", "/ril_0", "org.ofono.VoiceCallManager", "CallAdded", this, SLOT(callAdded(QDBusMessage)));
-    systemBus.connect("org.ofono", "/ril_0", "org.ofono.VoiceCallManager", "CallRemoved", this, SLOT(callRemoved()));
+    systemBus.connect("org.ofono", "/ril_0", "org.ofono.VoiceCallManager", "CallRemoved", this, SLOT(callEnded()));
 }
 
 bool SailfishHelper::eventFilter(QObject *obj, QEvent *event)
@@ -72,56 +69,18 @@ bool SailfishHelper::eventFilter(QObject *obj, QEvent *event)
 
 void SailfishHelper::callAdded(const QDBusMessage &msg)
 {
-    qDebug() << "call";
     QDBusArgument *arg = (QDBusArgument*)msg.arguments().at(1).data();
     if (arg->currentType() != QDBusArgument::MapType) {
         return;
     }
 
-    Kodi *kodi = Kodi::instance();
     QMap<QString, QString> properties = unpackMessage(*arg);
 
-    qDebug() << properties;
-    qDebug() << properties.value("State");
-    qDebug() << m_settings->showCallNotifications();
-    if (properties.value("State") == "incoming" && m_settings->showCallNotifications()) {
-        QString phoneNumber = properties.value("LineIdentification");
-        QString contactName = lookupContact(phoneNumber);
+    QString phoneNumber = properties.value("LineIdentification");
+    QString contactName = lookupContact(phoneNumber);
 
-        QString caller = contactName.length() ? contactName : phoneNumber;
-        kodi->sendNotification(tr("Incoming call"), caller);
-    }
-
-    if(m_settings->changeVolumeOnCall()) {
-        kodi->dimVolumeTo(m_settings->volumeOnCall());
-    }
-
-    if(m_settings->pauseVideoOnCall() && kodi->videoPlayer()->state() == "playing") {
-        kodi->videoPlayer()->playPause();
-        m_videoPaused = true;
-    }
-
-    if(m_settings->pauseMusicOnCall() && kodi->audioPlayer()->state() == "playing") {
-        kodi->audioPlayer()->playPause();
-        m_musicPaused = true;
-    }
-}
-
-void SailfishHelper::callRemoved()
-{
-    qDebug() << "call removed";
-    if(m_settings->changeVolumeOnCall()) {
-        Kodi::instance()->restoreVolume();
-    }
-
-    if(m_videoPaused) {
-        Kodi::instance()->videoPlayer()->playPause();
-        m_videoPaused = false;
-    }
-    if(m_musicPaused) {
-        Kodi::instance()->audioPlayer()->playPause();
-        m_musicPaused = false;
-    }
+    QString caller = contactName.length() ? contactName : phoneNumber;
+    callStarted(properties.value("State") == "incoming", caller);
 }
 
 QString SailfishHelper::lookupContact(QString phoneNumber)

--- a/apps/sailfish/src/sailfishhelper.h
+++ b/apps/sailfish/src/sailfishhelper.h
@@ -27,6 +27,7 @@
 #include <QDBusObjectPath>
 #include <QObject>
 #include <policy/resource-set.h>
+#include <QQuickView>
 
 #include "libkodimote/platformhelper.h"
 
@@ -36,8 +37,11 @@ class SailfishHelper : public PlatformHelper
 {
     Q_OBJECT
 public:
-    explicit SailfishHelper(Settings *settings, QObject *parent = 0);
+    explicit SailfishHelper(QQuickView *quickView, Settings *settings, QObject *parent = 0);
     
+    bool canRaise() const;
+    void raise();
+
 private slots:
     void callAdded(const QDBusMessage &msg);
     bool eventFilter(QObject *obj, QEvent *event);
@@ -46,6 +50,7 @@ private:
     QString lookupContact(QString phoneNumber);
     QMap<QString, QString> unpackMessage(const QDBusArgument &args);
 
+    QQuickView *m_quickView;
     ResourcePolicy::ResourceSet *m_resourceSet;
 };
 

--- a/apps/sailfish/src/sailfishhelper.h
+++ b/apps/sailfish/src/sailfishhelper.h
@@ -28,9 +28,11 @@
 #include <QObject>
 #include <policy/resource-set.h>
 
+#include "libkodimote/platformhelper.h"
+
 class Settings;
 
-class SailfishHelper : public QObject
+class SailfishHelper : public PlatformHelper
 {
     Q_OBJECT
 public:
@@ -38,18 +40,13 @@ public:
     
 private slots:
     void callAdded(const QDBusMessage &msg);
-    void callRemoved();
     bool eventFilter(QObject *obj, QEvent *event);
 
 private:
     QString lookupContact(QString phoneNumber);
     QMap<QString, QString> unpackMessage(const QDBusArgument &args);
 
-    Settings *m_settings;
     ResourcePolicy::ResourceSet *m_resourceSet;
-
-    bool m_videoPaused;
-    bool m_musicPaused;
 };
 
 #endif // SAILFISHHELPER_H

--- a/apps/ubuntu/main.cpp
+++ b/apps/ubuntu/main.cpp
@@ -61,16 +61,21 @@ int main(int argc, char** argv)
     }
     application.installTranslator(&translator);
 
-    ProtocolManager protocols;
-
-    MprisController controller(&protocols);
-    Q_UNUSED(controller)
-
 
     Kodi::instance()->setDataPath(QDir::homePath() + "/.cache/com.ubuntu.developer.mzanetti.kodimote/");
     Kodi::instance()->eventClient()->setApplicationThumbnail("kodimote80.png");
 
     QQuickView *view = new QQuickView();
+
+    Settings settings;
+    UbuntuHelper helper(view, &settings);
+
+    ProtocolManager protocols;
+
+    MprisController controller(&protocols, &helper);
+    Q_UNUSED(controller)
+
+
     view->setResizeMode(QQuickView::SizeRootObjectToView);
 
     view->engine()->setNetworkAccessManagerFactory(new NetworkAccessManagerFactory());
@@ -78,13 +83,8 @@ int main(int argc, char** argv)
     view->setTitle("Kodimote");
     view->engine()->rootContext()->setContextProperty("kodi", Kodi::instance());
 
-
-    Settings settings;
     view->engine()->rootContext()->setContextProperty("settings", &settings);
     view->setSource(QUrl("qrc:///qml/main.qml"));
-
-    UbuntuHelper helper(&settings);
-    Q_UNUSED(helper);
 
     if(QGuiApplication::arguments().contains("--fullscreen")) {
         view->showFullScreen();

--- a/apps/ubuntu/main.cpp
+++ b/apps/ubuntu/main.cpp
@@ -22,6 +22,7 @@
 #include "libkodimote/settings.h"
 #include "libkodimote/eventclient.h"
 #include "libkodimote/networkaccessmanagerfactory.h"
+#include "libkodimote/mpris2/mpriscontroller.h"
 
 #include "ubuntuhelper.h"
 
@@ -59,6 +60,11 @@ int main(int argc, char** argv)
         qDebug() << "Cannot load translation file" << "kodimote_" + language + ".pm";
     }
     application.installTranslator(&translator);
+
+    ProtocolManager protocols;
+
+    MprisController controller(&protocols);
+    Q_UNUSED(controller)
 
 
     Kodi::instance()->setDataPath(QDir::homePath() + "/.cache/com.ubuntu.developer.mzanetti.kodimote/");

--- a/apps/ubuntu/qml/NowPlayingPage.qml
+++ b/apps/ubuntu/qml/NowPlayingPage.qml
@@ -298,7 +298,7 @@ KodiPage {
                     spacing: root.spacing
                     Label {
                         id: currentTime
-                        text: player ? player.time : "00:00"
+                        text: player ? player.timeString : "00:00"
                         width: (parent.width - parent.spacing) / 2
                     }
 

--- a/apps/ubuntu/ubuntuhelper.cpp
+++ b/apps/ubuntu/ubuntuhelper.cpp
@@ -25,8 +25,7 @@
 #include "ubuntuhelper.h"
 
 UbuntuHelper::UbuntuHelper(Settings *settings, QObject *parent) :
-    QObject(parent),
-    m_settings(settings)
+    PlatformHelper(settings, parent)
 {
 }
 

--- a/apps/ubuntu/ubuntuhelper.cpp
+++ b/apps/ubuntu/ubuntuhelper.cpp
@@ -24,8 +24,19 @@
 
 #include "ubuntuhelper.h"
 
-UbuntuHelper::UbuntuHelper(Settings *settings, QObject *parent) :
-    PlatformHelper(settings, parent)
+UbuntuHelper::UbuntuHelper(QQuickView *quickView, Settings *settings, QObject *parent) :
+    PlatformHelper(settings, parent),
+    m_quickView(quickView)
 {
+}
+
+bool UbuntuHelper::canRaise() const
+{
+    return true;
+}
+
+void UbuntuHelper::raise()
+{
+    m_quickView->raise();
 }
 

--- a/apps/ubuntu/ubuntuhelper.h
+++ b/apps/ubuntu/ubuntuhelper.h
@@ -23,16 +23,15 @@
 
 #include <QObject>
 
+#include "libkodimote/platformhelper.h"
+
 class Settings;
 
-class UbuntuHelper : public QObject
+class UbuntuHelper : public PlatformHelper
 {
     Q_OBJECT
 public:
     explicit UbuntuHelper(Settings *settings, QObject *parent = 0);
-
-private:
-    Settings *m_settings;
 };
 
 #endif

--- a/apps/ubuntu/ubuntuhelper.h
+++ b/apps/ubuntu/ubuntuhelper.h
@@ -22,6 +22,7 @@
 #define UBUNTUHELPER_H
 
 #include <QObject>
+#include <QQuickView>
 
 #include "libkodimote/platformhelper.h"
 
@@ -31,7 +32,13 @@ class UbuntuHelper : public PlatformHelper
 {
     Q_OBJECT
 public:
-    explicit UbuntuHelper(Settings *settings, QObject *parent = 0);
+    explicit UbuntuHelper(QQuickView *quickView, Settings *settings, QObject *parent = 0);
+
+    bool canRaise() const;
+    void raise();
+
+private:
+    QQuickView *m_quickView;
 };
 
 #endif

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -81,7 +81,8 @@ SOURCES +=  kodi.cpp \
             mpris2/mprisapplication.cpp \
             protocolhandlers/protocolhandler.cpp \
             protocolhandlers/youtubeprotocolhandler.cpp \
-            protocolhandlers/protocolmanager.cpp
+            protocolhandlers/protocolmanager.cpp \
+            protocolhandlers/nativeprotocolhandler.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -144,4 +145,5 @@ HEADERS += libkodimote_global.h \
            mpris2/mprisapplication.h \
            protocolhandlers/protocolhandler.h \
            protocolhandlers/youtubeprotocolhandler.h \
-           protocolhandlers/protocolmanager.h
+           protocolhandlers/protocolmanager.h \
+           protocolhandlers/nativeprotocolhandler.h

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -82,7 +82,8 @@ SOURCES +=  kodi.cpp \
             protocolhandlers/protocolhandler.cpp \
             protocolhandlers/youtubeprotocolhandler.cpp \
             protocolhandlers/protocolmanager.cpp \
-            protocolhandlers/nativeprotocolhandler.cpp
+            protocolhandlers/nativeprotocolhandler.cpp \
+            platformhelper.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -146,4 +147,5 @@ HEADERS += libkodimote_global.h \
            protocolhandlers/protocolhandler.h \
            protocolhandlers/youtubeprotocolhandler.h \
            protocolhandlers/protocolmanager.h \
-           protocolhandlers/nativeprotocolhandler.h
+           protocolhandlers/nativeprotocolhandler.h \
+           platformhelper.h

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -78,7 +78,10 @@ SOURCES +=  kodi.cpp \
             profileitem.cpp \
             mpris2/mpriscontroller.cpp \
             mpris2/mprisplayer.cpp \
-            mpris2/mprisapplication.cpp
+            mpris2/mprisapplication.cpp \
+            protocolhandlers/protocolhandler.cpp \
+            protocolhandlers/youtubeprotocolhandler.cpp \
+            protocolhandlers/protocolmanager.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -138,4 +141,7 @@ HEADERS += libkodimote_global.h \
            profileitem.h \
            mpris2/mpriscontroller.h \
            mpris2/mprisplayer.h \
-           mpris2/mprisapplication.h
+           mpris2/mprisapplication.h \
+           protocolhandlers/protocolhandler.h \
+           protocolhandlers/youtubeprotocolhandler.h \
+           protocolhandlers/protocolmanager.h

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -1,4 +1,4 @@
-QT += concurrent network
+QT += concurrent network dbus
 contains(QT_VERSION, ^5\\..\\..*) {
     DEFINES += QT5_BUILD
     QT += quick qml
@@ -75,7 +75,10 @@ SOURCES +=  kodi.cpp \
             kodihost.cpp \
             addonsource.cpp \
             profiles.cpp \
-            profileitem.cpp
+            profileitem.cpp \
+            mpris2/mpriscontroller.cpp \
+            mpris2/mprisplayer.cpp \
+            mpris2/mprisapplication.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -132,4 +135,7 @@ HEADERS += libkodimote_global.h \
            kodihost.h \
            addonsource.h \
            profiles.h \
-           profileitem.h
+           profileitem.h \
+           mpris2/mpriscontroller.h \
+           mpris2/mprisplayer.h \
+           mpris2/mprisapplication.h

--- a/libkodimote/mpris2/mprisapplication.cpp
+++ b/libkodimote/mpris2/mprisapplication.cpp
@@ -1,0 +1,80 @@
+#include "mprisapplication.h"
+
+#include "kodi.h"
+#include "kodihost.h"
+#include "keys.h"
+
+MprisApplication::MprisApplication(QObject *parent) :
+    QDBusAbstractAdaptor(parent)
+{
+}
+
+bool MprisApplication::canQuit() const
+{
+    return true;
+}
+
+bool MprisApplication::canSetFullscreen() const
+{
+    return false;
+}
+
+bool MprisApplication::canRaise() const
+{
+    return false;
+}
+
+bool MprisApplication::hasTrackList() const
+{
+    return false;
+}
+
+QString MprisApplication::identity() const
+{
+    KodiHost *host = Kodi::instance()->connectedHost();
+    if (host) {
+        return tr("Kodi on %1").arg(host->hostname());
+    } else {
+        return "Kodimote";
+    }
+}
+
+QString MprisApplication::desktopEntry() const
+{
+#ifdef SAILFISH
+    return "harbour-kodimote";
+#else
+    return "kodimote";
+#endif
+}
+
+QStringList MprisApplication::supportedUriSchemes() const
+{
+    QStringList schemes;
+    return schemes;
+}
+
+QStringList MprisApplication::supportedMimeTypes() const
+{
+    QStringList mimeTypes;
+    return mimeTypes;
+}
+
+bool MprisApplication::fullscreen() const
+{
+    return true;
+}
+
+void MprisApplication::setFullscreen(bool fullscreen)
+{
+    Q_UNUSED(fullscreen)
+}
+
+void MprisApplication::Quit()
+{
+    Kodi::instance()->quit();
+}
+
+void MprisApplication::Raise()
+{
+}

--- a/libkodimote/mpris2/mprisapplication.cpp
+++ b/libkodimote/mpris2/mprisapplication.cpp
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #include "mprisapplication.h"
 
 #include "kodi.h"

--- a/libkodimote/mpris2/mprisapplication.cpp
+++ b/libkodimote/mpris2/mprisapplication.cpp
@@ -4,8 +4,9 @@
 #include "kodihost.h"
 #include "keys.h"
 
-MprisApplication::MprisApplication(QObject *parent) :
-    QDBusAbstractAdaptor(parent)
+MprisApplication::MprisApplication(ProtocolManager *protocols, QObject *parent) :
+    QDBusAbstractAdaptor(parent),
+    m_protocols(protocols)
 {
 }
 
@@ -51,6 +52,11 @@ QString MprisApplication::desktopEntry() const
 QStringList MprisApplication::supportedUriSchemes() const
 {
     QStringList schemes;
+
+    foreach (ProtocolHandler *protocol, m_protocols->list()) {
+        schemes.append(protocol->scheme());
+    }
+
     return schemes;
 }
 

--- a/libkodimote/mpris2/mprisapplication.cpp
+++ b/libkodimote/mpris2/mprisapplication.cpp
@@ -25,9 +25,10 @@
 #include "kodihost.h"
 #include "keys.h"
 
-MprisApplication::MprisApplication(ProtocolManager *protocols, QObject *parent) :
+MprisApplication::MprisApplication(ProtocolManager *protocols, PlatformHelper *platform, QObject *parent) :
     QDBusAbstractAdaptor(parent),
-    m_protocols(protocols)
+    m_protocols(protocols),
+    m_platform(platform)
 {
 }
 
@@ -43,7 +44,7 @@ bool MprisApplication::canSetFullscreen() const
 
 bool MprisApplication::canRaise() const
 {
-    return false;
+    return m_platform->canRaise();
 }
 
 bool MprisApplication::hasTrackList() const
@@ -104,4 +105,5 @@ void MprisApplication::Quit()
 
 void MprisApplication::Raise()
 {
+    m_platform->raise();
 }

--- a/libkodimote/mpris2/mprisapplication.h
+++ b/libkodimote/mpris2/mprisapplication.h
@@ -3,6 +3,8 @@
 
 #include <QtDBus/QDBusAbstractAdaptor>
 
+#include "protocolhandlers/protocolmanager.h"
+
 class MprisApplication : public QDBusAbstractAdaptor
 {
     Q_OBJECT
@@ -17,7 +19,7 @@ class MprisApplication : public QDBusAbstractAdaptor
     Q_PROPERTY(bool Fullscreen READ fullscreen WRITE setFullscreen)
     Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2")
 public:
-    explicit MprisApplication(QObject *parent = 0);
+    explicit MprisApplication(ProtocolManager *protocols, QObject *parent = 0);
 
     bool canQuit() const;
     bool canSetFullscreen() const;
@@ -34,6 +36,9 @@ public:
 public slots:
     void Quit();
     void Raise();
+
+private:
+    ProtocolManager *m_protocols;
 };
 
 #endif // MPRISAPPLICATION_H

--- a/libkodimote/mpris2/mprisapplication.h
+++ b/libkodimote/mpris2/mprisapplication.h
@@ -1,0 +1,39 @@
+#ifndef MPRISAPPLICATION_H
+#define MPRISAPPLICATION_H
+
+#include <QtDBus/QDBusAbstractAdaptor>
+
+class MprisApplication : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_PROPERTY(bool CanQuit READ canQuit)
+    Q_PROPERTY(bool CanSetFullscreen READ canSetFullscreen)
+    Q_PROPERTY(bool CanRaise READ canRaise)
+    Q_PROPERTY(bool HasTrackList READ hasTrackList)
+    Q_PROPERTY(QString Identity READ identity)
+    Q_PROPERTY(QString DesktopEntry READ desktopEntry)
+    Q_PROPERTY(QStringList SupportedUriSchemes READ supportedUriSchemes)
+    Q_PROPERTY(QStringList SupportedMimeTypes READ supportedMimeTypes)
+    Q_PROPERTY(bool Fullscreen READ fullscreen WRITE setFullscreen)
+    Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2")
+public:
+    explicit MprisApplication(QObject *parent = 0);
+
+    bool canQuit() const;
+    bool canSetFullscreen() const;
+    bool canRaise() const;
+    bool hasTrackList() const;
+    QString identity() const;
+    QString desktopEntry() const;
+    QStringList supportedUriSchemes() const;
+    QStringList supportedMimeTypes() const;
+
+    bool fullscreen() const;
+    void setFullscreen(bool fullscreen);
+
+public slots:
+    void Quit();
+    void Raise();
+};
+
+#endif // MPRISAPPLICATION_H

--- a/libkodimote/mpris2/mprisapplication.h
+++ b/libkodimote/mpris2/mprisapplication.h
@@ -25,6 +25,7 @@
 #include <QtDBus/QDBusAbstractAdaptor>
 
 #include "protocolhandlers/protocolmanager.h"
+#include "../platformhelper.h"
 
 class MprisApplication : public QDBusAbstractAdaptor
 {
@@ -40,7 +41,7 @@ class MprisApplication : public QDBusAbstractAdaptor
     Q_PROPERTY(bool Fullscreen READ fullscreen WRITE setFullscreen)
     Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2")
 public:
-    explicit MprisApplication(ProtocolManager *protocols, QObject *parent = 0);
+    explicit MprisApplication(ProtocolManager *protocols, PlatformHelper *platform, QObject *parent = 0);
 
     bool canQuit() const;
     bool canSetFullscreen() const;
@@ -60,6 +61,7 @@ public slots:
 
 private:
     ProtocolManager *m_protocols;
+    PlatformHelper *m_platform;
 };
 
 #endif // MPRISAPPLICATION_H

--- a/libkodimote/mpris2/mprisapplication.h
+++ b/libkodimote/mpris2/mprisapplication.h
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #ifndef MPRISAPPLICATION_H
 #define MPRISAPPLICATION_H
 

--- a/libkodimote/mpris2/mpriscontroller.cpp
+++ b/libkodimote/mpris2/mpriscontroller.cpp
@@ -6,14 +6,14 @@
 #include "mprisapplication.h"
 #include "mprisplayer.h"
 
-MprisController::MprisController(QObject *parent) :
+MprisController::MprisController(ProtocolManager *protocols, QObject *parent) :
     QObject(parent)
 {
     QDBusConnection bus = QDBusConnection::sessionBus();
 
     bus.registerService("org.mpris.MediaPlayer2.kodimote");
-    new MprisPlayer(this);
-    new MprisApplication(this);
+    new MprisPlayer(protocols, this);
+    new MprisApplication(protocols, this);
 
     bus.registerObject("/org/mpris/MediaPlayer2", this);
 }

--- a/libkodimote/mpris2/mpriscontroller.cpp
+++ b/libkodimote/mpris2/mpriscontroller.cpp
@@ -27,14 +27,14 @@
 #include "mprisapplication.h"
 #include "mprisplayer.h"
 
-MprisController::MprisController(ProtocolManager *protocols, QObject *parent) :
+MprisController::MprisController(ProtocolManager *protocols, PlatformHelper *platform, QObject *parent) :
     QObject(parent)
 {
     QDBusConnection bus = QDBusConnection::sessionBus();
 
     bus.registerService("org.mpris.MediaPlayer2.kodimote");
     new MprisPlayer(protocols, this);
-    new MprisApplication(protocols, this);
+    new MprisApplication(protocols, platform, this);
 
     bus.registerObject("/org/mpris/MediaPlayer2", this);
 }

--- a/libkodimote/mpris2/mpriscontroller.cpp
+++ b/libkodimote/mpris2/mpriscontroller.cpp
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #include "mpriscontroller.h"
 
 #include <QGuiApplication>

--- a/libkodimote/mpris2/mpriscontroller.cpp
+++ b/libkodimote/mpris2/mpriscontroller.cpp
@@ -1,0 +1,19 @@
+#include "mpriscontroller.h"
+
+#include <QGuiApplication>
+#include <QtDBus/QtDBus>
+
+#include "mprisapplication.h"
+#include "mprisplayer.h"
+
+MprisController::MprisController(QObject *parent) :
+    QObject(parent)
+{
+    QDBusConnection bus = QDBusConnection::sessionBus();
+
+    bus.registerService("org.mpris.MediaPlayer2.kodimote");
+    new MprisPlayer(this);
+    new MprisApplication(this);
+
+    bus.registerObject("/org/mpris/MediaPlayer2", this);
+}

--- a/libkodimote/mpris2/mpriscontroller.h
+++ b/libkodimote/mpris2/mpriscontroller.h
@@ -1,0 +1,15 @@
+#ifndef MPRISCONTROLLER_H
+#define MPRISCONTROLLER_H
+
+#include <QObject>
+#include <QWindow>
+
+class MprisController : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MprisController(QObject *parent = 0);
+
+};
+
+#endif // MPRISCONTROLLER_H

--- a/libkodimote/mpris2/mpriscontroller.h
+++ b/libkodimote/mpris2/mpriscontroller.h
@@ -4,11 +4,13 @@
 #include <QObject>
 #include <QWindow>
 
+#include "../protocolhandlers/protocolmanager.h"
+
 class MprisController : public QObject
 {
     Q_OBJECT
 public:
-    explicit MprisController(QObject *parent = 0);
+    explicit MprisController(ProtocolManager *protocols, QObject *parent = 0);
 
 };
 

--- a/libkodimote/mpris2/mpriscontroller.h
+++ b/libkodimote/mpris2/mpriscontroller.h
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #ifndef MPRISCONTROLLER_H
 #define MPRISCONTROLLER_H
 

--- a/libkodimote/mpris2/mpriscontroller.h
+++ b/libkodimote/mpris2/mpriscontroller.h
@@ -26,12 +26,13 @@
 #include <QWindow>
 
 #include "../protocolhandlers/protocolmanager.h"
+#include "../platformhelper.h"
 
 class MprisController : public QObject
 {
     Q_OBJECT
 public:
-    explicit MprisController(ProtocolManager *protocols, QObject *parent = 0);
+    explicit MprisController(ProtocolManager *protocols, PlatformHelper *platform, QObject *parent = 0);
 
 };
 

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -72,7 +72,10 @@ QVariantMap MprisPlayer::metadata()
     QVariantMap map;
     if (m_player && m_player->currentItem()) {
         LibraryItem *item = m_player->currentItem();
-        map["mpris:trackid"] = qVariantFromValue(QDBusObjectPath(buildPath(item)));
+        QString path = buildPath(item);
+        if (path != "") {
+            map["mpris:trackid"] = qVariantFromValue(QDBusObjectPath(path));
+        }
         map["mpris:length"] = QTime(0, 0, 0).msecsTo(item->duration()) * Q_INT64_C(1000); // milliseconds vs microseconds
         map["xesam:title"] = item->title();
         map["xesam:artist"] = item->subtitle();

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -1,6 +1,7 @@
 #include "mprisplayer.h"
 
 #include "kodi.h"
+#include "libraryitem.h"
 #include "player.h"
 #include "playlist.h"
 
@@ -54,9 +55,28 @@ bool MprisPlayer::canSeek() const
     return false;
 }
 
+double MprisPlayer::maximumRate() const
+{
+    return 32.0;
+}
+
+double MprisPlayer::minimumRate() const
+{
+    return -32.0;
+}
+
 QVariantMap MprisPlayer::metadata() const
 {
     QVariantMap map;
+    if (m_player && m_player->currentItem()) {
+        LibraryItem *item = m_player->currentItem();
+        if (item->episodeId() > -1) {
+            map["mpris:trackid"] = QString("/org/mpris/MediaPlayer2/Track/ep%1").arg(item->episodeId());
+        }
+        map["xesam:title"] = item->title();
+        map["xesam:artist"] = item->subtitle();
+        map["mpris:length"] = QTime(0, 0, 0).msecsTo(item->duration()) * Q_INT64_C(1000); // milliseconds vs microseconds
+    }
     return map;
 }
 
@@ -73,6 +93,26 @@ QString MprisPlayer::playbackStatus() const
     } else {
         return "Stopped";
     }
+}
+
+qint64 MprisPlayer::position() const
+{
+    if (!m_player) {
+        return 0;
+    }
+
+    m_player->updatePlaytime();
+    QTime time = m_player->time();
+    return QTime(0, 0, 0).msecsTo(time) * Q_INT64_C(1000); // milliseconds vs microseconds
+}
+
+double MprisPlayer::rate() const
+{
+    if (!m_player) {
+        return 1.0;
+    }
+
+    return m_player->speed();
 }
 
 void MprisPlayer::Next()
@@ -128,12 +168,12 @@ void MprisPlayer::Stop()
     m_player->stop();
 }
 
-/*void MprisPlayer::Seek(int64_t offset)
+/*void MprisPlayer::Seek(qint64 offset)
 {
 
 }*/
 
-/*void MprisPlayer::SetPosition(QDBusObjectPath path, int64_t position)
+/*void MprisPlayer::SetPosition(QDBusObjectPath path, qint64 position)
 {
 
 }*/
@@ -159,6 +199,7 @@ void MprisPlayer::activePlayerChanged()
     if (m_player) {
         connect(m_player, SIGNAL(stateChanged()), this, SLOT(stateChanged()));
         connect(m_player, SIGNAL(currentItemChanged()), this, SLOT(currentItemChanged()));
+        connect(m_player, SIGNAL(timeChanged()), this, SLOT(timeChanged));
         connect(m_player->playlist(), SIGNAL(countChanged()), this, SLOT(playlistChanged()));
     }
 
@@ -188,6 +229,18 @@ void MprisPlayer::currentItemChanged()
     changedProps.insert("CanSeek", canSeek());
     changedProps.insert("Metadata", metadata());
     changedProps.insert("PlaybackStatus", playbackStatus());
+    changedProps.insert("Position", position());
+    signal << changedProps;
+    signal << QStringList();
+    QDBusConnection::sessionBus().send(signal);
+}
+
+void MprisPlayer::timeChanged()
+{
+    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    signal << "org.mpris.MediaPlayer2.Player";
+    QVariantMap changedProps;
+    changedProps.insert("Position", position());
     signal << changedProps;
     signal << QStringList();
     QDBusConnection::sessionBus().send(signal);

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -5,9 +5,11 @@
 #include "playlist.h"
 
 MprisPlayer::MprisPlayer(QObject *parent) :
-    QDBusAbstractAdaptor(parent)
+    QDBusAbstractAdaptor(parent),
+    m_player(Kodi::instance()->activePlayer())
 {
-    setAutoRelaySignals(true);
+    setAutoRelaySignals(false);
+    connect(Kodi::instance(), SIGNAL(activePlayerChanged()), SLOT(activePlayerChanged()));
 }
 
 bool MprisPlayer::canControl() const
@@ -17,22 +19,20 @@ bool MprisPlayer::canControl() const
 
 bool MprisPlayer::canGoNext() const
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return false;
     }
 
-    return player->playlist()->currentTrackNumber() < player->playlist()->count();
+    return m_player->playlist()->currentTrackNumber() < m_player->playlist()->count();
 }
 
 bool MprisPlayer::canGoPrevious() const
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return false;
     }
 
-    return player->playlist()->currentTrackNumber() > 1;
+    return m_player->playlist()->currentTrackNumber() > 1;
 }
 
 bool MprisPlayer::canPause() const
@@ -42,12 +42,11 @@ bool MprisPlayer::canPause() const
 
 bool MprisPlayer::canPlay() const
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return false;
     }
 
-    return !!player->currentItem();
+    return !!m_player->currentItem();
 }
 
 bool MprisPlayer::canSeek() const
@@ -63,14 +62,13 @@ QVariantMap MprisPlayer::metadata() const
 
 QString MprisPlayer::playbackStatus() const
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return "Stopped";
     }
 
-    if (player->state() == "playing") {
+    if (m_player->state() == "playing") {
         return "Playing";
-    } else if (player->state() == "paused") {
+    } else if (m_player->state() == "paused") {
         return "Paused";
     } else {
         return "Stopped";
@@ -79,61 +77,55 @@ QString MprisPlayer::playbackStatus() const
 
 void MprisPlayer::Next()
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return;
     }
 
-    player->skipNext();
+    m_player->skipNext();
 }
 
 void MprisPlayer::Previous()
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return;
     }
 
-    player->skipPrevious();
+    m_player->skipPrevious();
 }
 
 void MprisPlayer::Pause()
 {
-    Player *player = activePlayer();
-    if (!player || player->state() != "playing") {
+    if (!m_player || m_player->state() != "playing") {
         return;
     }
 
-    player->playPause();
+    m_player->playPause();
 }
 
 void MprisPlayer::PlayPause()
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return;
     }
 
-    player->playPause();
+    m_player->playPause();
 }
 
 void MprisPlayer::Play()
 {
-    Player *player = activePlayer();
-    if (!player || player->state() == "playing") {
+    if (!m_player || m_player->state() == "playing") {
         return;
     }
 
-    player->playPause();
+    m_player->playPause();
 }
 
 void MprisPlayer::Stop()
 {
-    Player *player = activePlayer();
-    if (!player) {
+    if (!m_player) {
         return;
     }
-    player->stop();
+    m_player->stop();
 }
 
 /*void MprisPlayer::Seek(int64_t offset)
@@ -151,7 +143,64 @@ void MprisPlayer::Stop()
 
 }*/
 
-Player *MprisPlayer::activePlayer() const
+void MprisPlayer::activePlayerChanged()
 {
-    return Kodi::instance()->activePlayer();
+    if (m_player == Kodi::instance()->activePlayer()) {
+        return;
+    }
+
+    if (m_player) {
+        disconnect(m_player, 0, this, 0);
+        disconnect(m_player->playlist(), SIGNAL(countChanged()), this, SLOT(playlistChanged()));
+    }
+
+    m_player = Kodi::instance()->activePlayer();
+
+    if (m_player) {
+        connect(m_player, SIGNAL(stateChanged()), this, SLOT(stateChanged()));
+        connect(m_player, SIGNAL(currentItemChanged()), this, SLOT(currentItemChanged()));
+        connect(m_player->playlist(), SIGNAL(countChanged()), this, SLOT(playlistChanged()));
+    }
+
+    currentItemChanged();
+}
+
+void MprisPlayer::stateChanged()
+{
+    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    signal << "org.mpris.MediaPlayer2.Player";
+    QVariantMap changedProps;
+    changedProps.insert("PlaybackStatus", playbackStatus());
+    signal << changedProps;
+    signal << QStringList();
+    QDBusConnection::sessionBus().send(signal);
+}
+
+void MprisPlayer::currentItemChanged()
+{
+    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    signal << "org.mpris.MediaPlayer2.Player";
+    QVariantMap changedProps;
+    changedProps.insert("CanGoNext", canGoNext());
+    changedProps.insert("CanGoPrevious", canGoPrevious());
+    changedProps.insert("CanPause", canPause());
+    changedProps.insert("CanPlay", canPlay());
+    changedProps.insert("CanSeek", canSeek());
+    changedProps.insert("Metadata", metadata());
+    changedProps.insert("PlaybackStatus", playbackStatus());
+    signal << changedProps;
+    signal << QStringList();
+    QDBusConnection::sessionBus().send(signal);
+}
+
+void MprisPlayer::playlistChanged()
+{
+    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    signal << "org.mpris.MediaPlayer2.Player";
+    QVariantMap changedProps;
+    changedProps.insert("CanGoNext", canGoNext());
+    changedProps.insert("CanGoPrevious", canGoPrevious());
+    signal << changedProps;
+    signal << QStringList();
+    QDBusConnection::sessionBus().send(signal);
 }

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -52,7 +52,7 @@ bool MprisPlayer::canPlay() const
 
 bool MprisPlayer::canSeek() const
 {
-    return false;
+    return true;
 }
 
 double MprisPlayer::maximumRate() const
@@ -71,7 +71,7 @@ QVariantMap MprisPlayer::metadata() const
     if (m_player && m_player->currentItem()) {
         LibraryItem *item = m_player->currentItem();
         if (item->episodeId() > -1) {
-            map["mpris:trackid"] = QString("/org/mpris/MediaPlayer2/Track/ep%1").arg(item->episodeId());
+            map["mpris:trackid"] = qVariantFromValue(QDBusObjectPath(QString("/org/mpris/MediaPlayer2/Track/ep%1").arg(item->episodeId())));
         }
         map["xesam:title"] = item->title();
         map["xesam:artist"] = item->subtitle();
@@ -112,7 +112,7 @@ double MprisPlayer::rate() const
         return 1.0;
     }
 
-    return m_player->speed();
+    return m_player->state() == "playing" ? m_player->speed() : 1.0;
 }
 
 void MprisPlayer::Next()
@@ -199,7 +199,7 @@ void MprisPlayer::activePlayerChanged()
     if (m_player) {
         connect(m_player, SIGNAL(stateChanged()), this, SLOT(stateChanged()));
         connect(m_player, SIGNAL(currentItemChanged()), this, SLOT(currentItemChanged()));
-        connect(m_player, SIGNAL(timeChanged()), this, SLOT(timeChanged));
+        connect(m_player, SIGNAL(timeChanged()), this, SLOT(timeChanged()));
         connect(m_player->playlist(), SIGNAL(countChanged()), this, SLOT(playlistChanged()));
     }
 
@@ -230,6 +230,7 @@ void MprisPlayer::currentItemChanged()
     changedProps.insert("Metadata", metadata());
     changedProps.insert("PlaybackStatus", playbackStatus());
     changedProps.insert("Position", position());
+    changedProps.insert("Rate", rate());
     signal << changedProps;
     signal << QStringList();
     QDBusConnection::sessionBus().send(signal);
@@ -237,10 +238,15 @@ void MprisPlayer::currentItemChanged()
 
 void MprisPlayer::timeChanged()
 {
+    emit Seeked(QTime(0, 0, 0).msecsTo(m_player->time()) * Q_INT64_C(1000));
+}
+
+void MprisPlayer::speedChanged()
+{
     QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
     signal << "org.mpris.MediaPlayer2.Player";
     QVariantMap changedProps;
-    changedProps.insert("Position", position());
+    changedProps.insert("Rate", rate());
     signal << changedProps;
     signal << QStringList();
     QDBusConnection::sessionBus().send(signal);

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -293,6 +293,8 @@ QString MprisPlayer::buildPath(LibraryItem *item) const
         return QString("/org/mpris/MediaPlayer2/Track/channel/%1").arg(item->channelId());
     } else if (item->songId() != -1) {
         return QString("/org/mpris/MediaPlayer2/Track/song/%1").arg(item->songId());
+    } else if (item->recordingId() != -1) {
+        return QString("/org/mpris/MediaPlayer2/Track/recording/%1").arg(item->recordingId());
     }
 
     return "";

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -265,15 +265,7 @@ void MprisPlayer::SetPosition(QDBusObjectPath path, qint64 position)
 
 void MprisPlayer::OpenUri(QString uri)
 {
-    QUrl url(uri);
-    ProtocolHandler *handler = m_protocols->get(url.scheme());
-
-    if (!handler) {
-        return;
-    }
-
-    QUrlQuery query(url);
-    handler->execute(url, query.hasQueryItem("queue"));
+    m_protocols->execute(uri);
 }
 
 QString MprisPlayer::buildPath(LibraryItem *item) const

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -293,6 +293,24 @@ QString MprisPlayer::buildPath(LibraryItem *item) const
     return "";
 }
 
+void MprisPlayer::sendPropertyChanged(const QString &property)
+{
+    sendPropertiesChanged(QStringList(property));
+}
+
+void MprisPlayer::sendPropertiesChanged(const QStringList &properties)
+{
+    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    signal << "org.mpris.MediaPlayer2.Player";
+    QVariantMap changedProps;
+    foreach (QString property, properties) {
+        changedProps.insert(property, this->property(property.toUtf8()));
+    }
+    signal << changedProps;
+    signal << QStringList();
+    QDBusConnection::sessionBus().send(signal);
+}
+
 void MprisPlayer::activePlayerChanged()
 {
     if (m_player == Kodi::instance()->activePlayer()) {
@@ -321,43 +339,18 @@ void MprisPlayer::activePlayerChanged()
 
 void MprisPlayer::volumeChanged()
 {
-    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
-    signal << "org.mpris.MediaPlayer2.Player";
-    QVariantMap changedProps;
-    changedProps.insert("Volume", volume());
-    signal << changedProps;
-    signal << QStringList();
-    QDBusConnection::sessionBus().send(signal);
+    sendPropertyChanged("Volume");
 }
 
 void MprisPlayer::stateChanged()
 {
-    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
-    signal << "org.mpris.MediaPlayer2.Player";
-    QVariantMap changedProps;
-    changedProps.insert("PlaybackStatus", playbackStatus());
-    signal << changedProps;
-    signal << QStringList();
-    QDBusConnection::sessionBus().send(signal);
+    sendPropertyChanged("PlaybackStatus");
 }
 
 void MprisPlayer::currentItemChanged()
 {
-    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
-    signal << "org.mpris.MediaPlayer2.Player";
-    QVariantMap changedProps;
-    changedProps.insert("CanGoNext", canGoNext());
-    changedProps.insert("CanGoPrevious", canGoPrevious());
-    changedProps.insert("CanPause", canPause());
-    changedProps.insert("CanPlay", canPlay());
-    changedProps.insert("CanSeek", canSeek());
-    changedProps.insert("Metadata", metadata());
-    changedProps.insert("PlaybackStatus", playbackStatus());
-    changedProps.insert("Position", position());
-    changedProps.insert("Rate", rate());
-    signal << changedProps;
-    signal << QStringList();
-    QDBusConnection::sessionBus().send(signal);
+    sendPropertiesChanged(QStringList() << "CanGoNext" << "CanGoPrevious" << "CanPause"
+        << "CanPlay" << "CanSeek" << "Metadata" << "PlaybackStatus" << "Position" << "Rate");
 }
 
 void MprisPlayer::timeChanged()
@@ -367,45 +360,20 @@ void MprisPlayer::timeChanged()
 
 void MprisPlayer::speedChanged()
 {
-    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
-    signal << "org.mpris.MediaPlayer2.Player";
-    QVariantMap changedProps;
-    changedProps.insert("Rate", rate());
-    signal << changedProps;
-    signal << QStringList();
-    QDBusConnection::sessionBus().send(signal);
+    sendPropertyChanged("Rate");
 }
 
 void MprisPlayer::shuffleChanged()
 {
-    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
-    signal << "org.mpris.MediaPlayer2.Player";
-    QVariantMap changedProps;
-    changedProps.insert("Shuffle", shuffle());
-    signal << changedProps;
-    signal << QStringList();
-    QDBusConnection::sessionBus().send(signal);
+    sendPropertyChanged("Shuffle");
 }
 
 void MprisPlayer::repeatChanged()
 {
-    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
-    signal << "org.mpris.MediaPlayer2.Player";
-    QVariantMap changedProps;
-    changedProps.insert("LoopStatus", loopStatus());
-    signal << changedProps;
-    signal << QStringList();
-    QDBusConnection::sessionBus().send(signal);
+    sendPropertyChanged("LoopStatus");
 }
 
 void MprisPlayer::playlistChanged()
 {
-    QDBusMessage signal = QDBusMessage::createSignal("/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "PropertiesChanged");
-    signal << "org.mpris.MediaPlayer2.Player";
-    QVariantMap changedProps;
-    changedProps.insert("CanGoNext", canGoNext());
-    changedProps.insert("CanGoPrevious", canGoPrevious());
-    signal << changedProps;
-    signal << QStringList();
-    QDBusConnection::sessionBus().send(signal);
+    sendPropertiesChanged(QStringList() << "CanGoNext" << "CanGoPrevious");
 }

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -5,9 +5,10 @@
 #include "player.h"
 #include "playlist.h"
 
-MprisPlayer::MprisPlayer(QObject *parent) :
+MprisPlayer::MprisPlayer(ProtocolManager *protocols, QObject *parent) :
     QDBusAbstractAdaptor(parent),
-    m_player(Kodi::instance()->activePlayer())
+    m_player(Kodi::instance()->activePlayer()),
+    m_protocols(protocols)
 {
     setAutoRelaySignals(false);
     connect(Kodi::instance(), SIGNAL(activePlayerChanged()), SLOT(activePlayerChanged()));
@@ -202,10 +203,18 @@ void MprisPlayer::SetPosition(QDBusObjectPath path, qint64 position)
     m_player->seek(time);
 }
 
-/*void MprisPlayer::OpenUri(QString uri)
+void MprisPlayer::OpenUri(QString uri)
 {
+    QUrl url(uri);
+    ProtocolHandler *handler = m_protocols->get(url.scheme());
 
-}*/
+    if (!handler) {
+        return;
+    }
+
+    QUrlQuery query(url);
+    handler->execute(url, query.hasQueryItem("queue"));
+}
 
 QString MprisPlayer::buildPath(LibraryItem *item) const
 {

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -70,12 +70,11 @@ QVariantMap MprisPlayer::metadata() const
     QVariantMap map;
     if (m_player && m_player->currentItem()) {
         LibraryItem *item = m_player->currentItem();
-        if (item->episodeId() > -1) {
-            map["mpris:trackid"] = qVariantFromValue(QDBusObjectPath(buildPath(item)));
-        }
+        map["mpris:trackid"] = qVariantFromValue(QDBusObjectPath(buildPath(item)));
+        map["mpris:length"] = QTime(0, 0, 0).msecsTo(item->duration()) * Q_INT64_C(1000); // milliseconds vs microseconds
         map["xesam:title"] = item->title();
         map["xesam:artist"] = item->subtitle();
-        map["mpris:length"] = QTime(0, 0, 0).msecsTo(item->duration()) * Q_INT64_C(1000); // milliseconds vs microseconds
+        map["xesam:album"] = item->album();
     }
     return map;
 }
@@ -215,6 +214,14 @@ QString MprisPlayer::buildPath(LibraryItem *item) const
 {
     if (item->episodeId() != -1) {
         return QString("/org/mpris/MediaPlayer2/Track/episode/%1").arg(item->episodeId());
+    } else if (item->movieId() != -1) {
+        return QString("/org/mpris/MediaPlayer2/Track/movie/%1").arg(item->movieId());
+    } else if (item->musicvideoId() != -1) {
+        return QString("/org/mpris/MediaPlayer2/Track/musicVideo/%1").arg(item->musicvideoId());
+    } else if (item->channelId() != -1) {
+        return QString("/org/mpris/MediaPlayer2/Track/channel/%1").arg(item->channelId());
+    } else if (item->songId() != -1) {
+        return QString("/org/mpris/MediaPlayer2/Track/song/%1").arg(item->songId());
     }
 
     return "";

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -1,0 +1,157 @@
+#include "mprisplayer.h"
+
+#include "kodi.h"
+#include "player.h"
+#include "playlist.h"
+
+MprisPlayer::MprisPlayer(QObject *parent) :
+    QDBusAbstractAdaptor(parent)
+{
+    setAutoRelaySignals(true);
+}
+
+bool MprisPlayer::canControl() const
+{
+    return true;
+}
+
+bool MprisPlayer::canGoNext() const
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return false;
+    }
+
+    return player->playlist()->currentTrackNumber() < player->playlist()->count();
+}
+
+bool MprisPlayer::canGoPrevious() const
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return false;
+    }
+
+    return player->playlist()->currentTrackNumber() > 1;
+}
+
+bool MprisPlayer::canPause() const
+{
+    return true;
+}
+
+bool MprisPlayer::canPlay() const
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return false;
+    }
+
+    return !!player->currentItem();
+}
+
+bool MprisPlayer::canSeek() const
+{
+    return false;
+}
+
+QVariantMap MprisPlayer::metadata() const
+{
+    QVariantMap map;
+    return map;
+}
+
+QString MprisPlayer::playbackStatus() const
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return "Stopped";
+    }
+
+    if (player->state() == "playing") {
+        return "Playing";
+    } else if (player->state() == "paused") {
+        return "Paused";
+    } else {
+        return "Stopped";
+    }
+}
+
+void MprisPlayer::Next()
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return;
+    }
+
+    player->skipNext();
+}
+
+void MprisPlayer::Previous()
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return;
+    }
+
+    player->skipPrevious();
+}
+
+void MprisPlayer::Pause()
+{
+    Player *player = activePlayer();
+    if (!player || player->state() != "playing") {
+        return;
+    }
+
+    player->playPause();
+}
+
+void MprisPlayer::PlayPause()
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return;
+    }
+
+    player->playPause();
+}
+
+void MprisPlayer::Play()
+{
+    Player *player = activePlayer();
+    if (!player || player->state() == "playing") {
+        return;
+    }
+
+    player->playPause();
+}
+
+void MprisPlayer::Stop()
+{
+    Player *player = activePlayer();
+    if (!player) {
+        return;
+    }
+    player->stop();
+}
+
+/*void MprisPlayer::Seek(int64_t offset)
+{
+
+}*/
+
+/*void MprisPlayer::SetPosition(QDBusObjectPath path, int64_t position)
+{
+
+}*/
+
+/*void MprisPlayer::OpenUri(QString uri)
+{
+
+}*/
+
+Player *MprisPlayer::activePlayer() const
+{
+    return Kodi::instance()->activePlayer();
+}

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #include "mprisplayer.h"
 
 #include "kodi.h"

--- a/libkodimote/mpris2/mprisplayer.cpp
+++ b/libkodimote/mpris2/mprisplayer.cpp
@@ -191,17 +191,14 @@ void MprisPlayer::Seek(qint64 offset)
 void MprisPlayer::SetPosition(QDBusObjectPath path, qint64 position)
 {
     if (!m_player || !m_player->currentItem()) {
-        qDebug() << "no player/item";
         return;
     }
 
     if (buildPath(m_player->currentItem()) != path.path()) {
-        qDebug() << "path doesn't match";
         return;
     }
 
     QTime time = QTime(0, 0, 0).addMSecs(position / 1000);
-    qDebug() << "seeking to" << time;
     m_player->seek(time);
 }
 
@@ -244,6 +241,7 @@ void MprisPlayer::activePlayerChanged()
         connect(m_player, SIGNAL(stateChanged()), this, SLOT(stateChanged()));
         connect(m_player, SIGNAL(currentItemChanged()), this, SLOT(currentItemChanged()));
         connect(m_player, SIGNAL(timeChanged()), this, SLOT(timeChanged()));
+        connect(m_player, SIGNAL(speedChanged()), this, SLOT(speedChanged()));
         connect(m_player->playlist(), SIGNAL(countChanged()), this, SLOT(playlistChanged()));
     }
 

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -72,6 +72,9 @@ private:
 
     QString buildPath(LibraryItem *item) const;
 
+    void sendPropertyChanged(const QString &property);
+    void sendPropertiesChanged(const QStringList &properties);
+
 private slots:
     void activePlayerChanged();
     void volumeChanged();

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -4,6 +4,7 @@
 #include <QtDBus/QtDBus>
 
 class Player;
+class LibraryItem;
 
 class MprisPlayer : public QDBusAbstractAdaptor
 {
@@ -47,12 +48,14 @@ public slots:
     void PlayPause();
     void Play();
     void Stop();
-    //void Seek(qint64 offset);
-    //void SetPosition(QDBusObjectPath path, qint64 position);
+    void Seek(qint64 offset);
+    void SetPosition(QDBusObjectPath path, qint64 position);
     //void OpenUri(QString uri);
 
 private:
     Player *m_player;
+
+    QString buildPath(LibraryItem *item) const;
 
 private slots:
     void activePlayerChanged();

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -38,7 +38,7 @@ public:
     bool canSeek() const;
     double maximumRate() const;
     double minimumRate() const;
-    QVariantMap metadata() const;
+    QVariantMap metadata();
     QString playbackStatus() const;
     qint64 position() const;
     double rate() const;
@@ -69,6 +69,7 @@ public slots:
 private:
     Player *m_player;
     ProtocolManager *m_protocols;
+    LibraryItem *m_currentItem;
 
     QString buildPath(LibraryItem *item) const;
 
@@ -85,6 +86,7 @@ private slots:
     void shuffleChanged();
     void repeatChanged();
     void playlistChanged();
+    void thumbnailChanged();
 };
 
 #endif // MPRISPLAYER_H

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -23,6 +23,9 @@ class MprisPlayer : public QDBusAbstractAdaptor
     Q_PROPERTY(QString PlaybackStatus READ playbackStatus)
     Q_PROPERTY(qint64 Position READ position)
     Q_PROPERTY(double Rate READ rate)
+    Q_PROPERTY(double Volume READ volume WRITE setVolume)
+    Q_PROPERTY(bool Shuffle READ shuffle WRITE setShuffle)
+    Q_PROPERTY(QString LoopStatus READ loopStatus WRITE setLoopStatus)
     Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2.Player")
 public:
     explicit MprisPlayer(ProtocolManager *protocols, QObject *parent = 0);
@@ -39,6 +42,15 @@ public:
     QString playbackStatus() const;
     qint64 position() const;
     double rate() const;
+
+    double volume() const;
+    void setVolume(double volume);
+
+    bool shuffle() const;
+    void setShuffle(bool shuffle);
+
+    QString loopStatus() const;
+    void setLoopStatus(QString loopStatus);
 
 signals:
     void Seeked(qint64);
@@ -62,10 +74,13 @@ private:
 
 private slots:
     void activePlayerChanged();
+    void volumeChanged();
     void currentItemChanged();
     void stateChanged();
     void timeChanged();
     void speedChanged();
+    void shuffleChanged();
+    void repeatChanged();
     void playlistChanged();
 };
 

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -1,0 +1,47 @@
+#ifndef MPRISPLAYER_H
+#define MPRISPLAYER_H
+
+#include <QtDBus/QtDBus>
+
+class Player;
+
+class MprisPlayer : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_PROPERTY(bool CanControl READ canControl)
+    Q_PROPERTY(bool CanGoNext READ canGoNext)
+    Q_PROPERTY(bool CanGoPrevious READ canGoPrevious)
+    Q_PROPERTY(bool CanPause READ canPause)
+    Q_PROPERTY(bool CanPlay READ canPlay)
+    Q_PROPERTY(bool CanSeek READ canSeek)
+    Q_PROPERTY(QVariantMap Metadata READ metadata)
+    Q_PROPERTY(QString PlaybackStatus READ playbackStatus)
+    Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2.Player")
+public:
+    explicit MprisPlayer(QObject *parent = 0);
+
+    bool canControl() const;
+    bool canGoNext() const;
+    bool canGoPrevious() const;
+    bool canPause() const;
+    bool canPlay() const;
+    bool canSeek() const;
+    QVariantMap metadata() const;
+    QString playbackStatus() const;
+
+public slots:
+    void Next();
+    void Previous();
+    void Pause();
+    void PlayPause();
+    void Play();
+    void Stop();
+    //void Seek(int64_t offset);
+    //void SetPosition(QDBusObjectPath path, int64_t position);
+    //void OpenUri(QString uri);
+
+private:
+    Player *activePlayer() const;
+};
+
+#endif // MPRISPLAYER_H

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -41,7 +41,13 @@ public slots:
     //void OpenUri(QString uri);
 
 private:
-    Player *activePlayer() const;
+    Player *m_player;
+
+private slots:
+    void activePlayerChanged();
+    void stateChanged();
+    void currentItemChanged();
+    void playlistChanged();
 };
 
 #endif // MPRISPLAYER_H

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #ifndef MPRISPLAYER_H
 #define MPRISPLAYER_H
 

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -37,6 +37,9 @@ public:
     qint64 position() const;
     double rate() const;
 
+signals:
+    void Seeked(qint64);
+
 public slots:
     void Next();
     void Previous();
@@ -56,6 +59,7 @@ private slots:
     void currentItemChanged();
     void stateChanged();
     void timeChanged();
+    void speedChanged();
     void playlistChanged();
 };
 

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -3,6 +3,8 @@
 
 #include <QtDBus/QtDBus>
 
+#include "protocolhandlers/protocolmanager.h"
+
 class Player;
 class LibraryItem;
 
@@ -23,7 +25,7 @@ class MprisPlayer : public QDBusAbstractAdaptor
     Q_PROPERTY(double Rate READ rate)
     Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2.Player")
 public:
-    explicit MprisPlayer(QObject *parent = 0);
+    explicit MprisPlayer(ProtocolManager *protocols, QObject *parent = 0);
 
     bool canControl() const;
     bool canGoNext() const;
@@ -50,10 +52,11 @@ public slots:
     void Stop();
     void Seek(qint64 offset);
     void SetPosition(QDBusObjectPath path, qint64 position);
-    //void OpenUri(QString uri);
+    void OpenUri(QString uri);
 
 private:
     Player *m_player;
+    ProtocolManager *m_protocols;
 
     QString buildPath(LibraryItem *item) const;
 

--- a/libkodimote/mpris2/mprisplayer.h
+++ b/libkodimote/mpris2/mprisplayer.h
@@ -14,8 +14,12 @@ class MprisPlayer : public QDBusAbstractAdaptor
     Q_PROPERTY(bool CanPause READ canPause)
     Q_PROPERTY(bool CanPlay READ canPlay)
     Q_PROPERTY(bool CanSeek READ canSeek)
+    Q_PROPERTY(double MaximumRate READ maximumRate)
+    Q_PROPERTY(double MinimumRate READ minimumRate)
     Q_PROPERTY(QVariantMap Metadata READ metadata)
     Q_PROPERTY(QString PlaybackStatus READ playbackStatus)
+    Q_PROPERTY(qint64 Position READ position)
+    Q_PROPERTY(double Rate READ rate)
     Q_CLASSINFO("D-Bus Interface", "org.mpris.MediaPlayer2.Player")
 public:
     explicit MprisPlayer(QObject *parent = 0);
@@ -26,8 +30,12 @@ public:
     bool canPause() const;
     bool canPlay() const;
     bool canSeek() const;
+    double maximumRate() const;
+    double minimumRate() const;
     QVariantMap metadata() const;
     QString playbackStatus() const;
+    qint64 position() const;
+    double rate() const;
 
 public slots:
     void Next();
@@ -36,8 +44,8 @@ public slots:
     void PlayPause();
     void Play();
     void Stop();
-    //void Seek(int64_t offset);
-    //void SetPosition(QDBusObjectPath path, int64_t position);
+    //void Seek(qint64 offset);
+    //void SetPosition(QDBusObjectPath path, qint64 position);
     //void OpenUri(QString uri);
 
 private:
@@ -45,8 +53,9 @@ private:
 
 private slots:
     void activePlayerChanged();
-    void stateChanged();
     void currentItemChanged();
+    void stateChanged();
+    void timeChanged();
     void playlistChanged();
 };
 

--- a/libkodimote/platformhelper.cpp
+++ b/libkodimote/platformhelper.cpp
@@ -1,0 +1,73 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
+#include "platformhelper.h"
+
+#include "kodi.h"
+#include "settings.h"
+#include "videoplayer.h"
+#include "audioplayer.h"
+
+PlatformHelper::PlatformHelper(Settings *settings, QObject *parent) :
+    QObject(parent),
+    m_settings(settings),
+    m_musicPaused(false),
+    m_videoPaused(false)
+{
+}
+
+void PlatformHelper::callStarted(bool incoming, const QString &caller)
+{
+    Kodi *kodi = Kodi::instance();
+    if (incoming && m_settings->showCallNotifications()) {
+        kodi->sendNotification(tr("Incoming call"), caller);
+    }
+
+    if(m_settings->changeVolumeOnCall()) {
+        kodi->dimVolumeTo(m_settings->volumeOnCall());
+    }
+
+    if(m_settings->pauseVideoOnCall() && kodi->videoPlayer()->state() == "playing") {
+        kodi->videoPlayer()->playPause();
+        m_videoPaused = true;
+    }
+
+    if(m_settings->pauseMusicOnCall() && kodi->audioPlayer()->state() == "playing") {
+        kodi->audioPlayer()->playPause();
+        m_musicPaused = true;
+    }
+}
+
+void PlatformHelper::callEnded()
+{
+    if(m_settings->changeVolumeOnCall()) {
+        Kodi::instance()->restoreVolume();
+    }
+
+    if(m_videoPaused) {
+        Kodi::instance()->videoPlayer()->playPause();
+        m_videoPaused = false;
+    }
+    if(m_musicPaused) {
+        Kodi::instance()->audioPlayer()->playPause();
+        m_musicPaused = false;
+    }
+}

--- a/libkodimote/platformhelper.h
+++ b/libkodimote/platformhelper.h
@@ -1,0 +1,46 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
+#ifndef PLATFORMHELPER_H
+#define PLATFORMHELPER_H
+
+#include <QObject>
+
+class Settings;
+
+class PlatformHelper : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PlatformHelper(Settings *settings, QObject *parent = 0);
+
+protected:
+    Settings *m_settings;
+protected slots:
+    void callStarted(bool incoming, const QString &caller);
+    void callEnded();
+
+private:
+    bool m_musicPaused;
+    bool m_videoPaused;
+};
+
+#endif // PLATFORMHELPER_H

--- a/libkodimote/platformhelper.h
+++ b/libkodimote/platformhelper.h
@@ -32,8 +32,12 @@ class PlatformHelper : public QObject
 public:
     explicit PlatformHelper(Settings *settings, QObject *parent = 0);
 
+    virtual bool canRaise() const { return false; }
+    virtual void raise() {}
+
 protected:
     Settings *m_settings;
+
 protected slots:
     void callStarted(bool incoming, const QString &caller);
     void callEnded();

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -372,7 +372,7 @@ void Player::detailsReceived(const QVariantMap &rsp)
 
     m_currentItem->setTitle(itemMap.value("label").toString());
     if(type == "song") {
-        m_currentItem->setSubtitle(itemMap.value("artist").toString());
+        m_currentItem->setSubtitle(itemMap.value("artist").toStringList().join("/"));
     } else if(type == "episode") {
         m_currentItem->setSubtitle(itemMap.value("showtitle").toString());
     } else if(type == "channel") {

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -343,6 +343,12 @@ void Player::detailsReceived(const QVariantMap &rsp)
 
     int id = itemMap.value("id").toInt();
     QString type = itemMap.value("type").toString();
+    if (type == "unknown") {
+        if (itemMap.value("file").toString().startsWith("pvr://")) {
+            type = "recording";
+        }
+    }
+
     if(type == "episode") {
         m_currentItem->setEpisodeId(id);
     } else if(type == "movie") {
@@ -357,17 +363,19 @@ void Player::detailsReceived(const QVariantMap &rsp)
         m_currentItem->setArtistId(id);
     } else if(type == "channel") {
         m_currentItem->setChannelId(id);
+    } else if(type == "recording") {
+        m_currentItem->setRecordingId(id);
     }
 
     m_currentItem->setType(type);
 
 
     m_currentItem->setTitle(itemMap.value("label").toString());
-    if(itemMap.value("type").toString() == "song") {
+    if(type == "song") {
         m_currentItem->setSubtitle(itemMap.value("artist").toString());
-    } else if(itemMap.value("type").toString() == "episode") {
+    } else if(type == "episode") {
         m_currentItem->setSubtitle(itemMap.value("showtitle").toString());
-    } else if(itemMap.value("type").toString() == "channel") {
+    } else if(type == "channel") {
         m_currentItem->setTitle(itemMap.value("title").toString());
         m_currentItem->setSubtitle(itemMap.value("label").toString());
     }

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -424,7 +424,7 @@ double Player::percentage() const
     return m_percentage;
 }
 
-QString Player::time() const
+QString Player::timeString() const
 {
     if(m_currentItem) {
         QTime time = QTime(0, 0, 0).addMSecs(m_lastPlaytime);

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -641,6 +641,25 @@ void Player::seek(double percentage)
     KodiConnection::sendCommand("Player.Seek", params);
 }
 
+void Player::seek(QTime time)
+{
+    if (m_seeking) {
+        return;
+    }
+
+    QVariantMap params;
+    params.insert("playerid", playerId());
+    QVariantMap position;
+    position.insert("hours", time.hour());
+    position.insert("minutes", time.minute());
+    position.insert("hours", time.hour());
+    position.insert("milliseconds", time.msec());
+    params.insert("value", position);
+
+    m_seeking = true;
+    KodiConnection::sendCommand("Player.Seek", params);
+}
+
 LibraryItem *Player::currentItem() const
 {
     return m_currentItem;

--- a/libkodimote/player.cpp
+++ b/libkodimote/player.cpp
@@ -424,17 +424,22 @@ double Player::percentage() const
     return m_percentage;
 }
 
+QTime Player::time() const
+{
+    QTime time(0, 0, 0);
+    if (m_currentItem) {
+        time = time.addMSecs(m_lastPlaytime);
+    }
+
+    return time;
+}
+
 QString Player::timeString() const
 {
-    if(m_currentItem) {
-        QTime time = QTime(0, 0, 0).addMSecs(m_lastPlaytime);
-        if(m_currentItem->duration().hour() > 0) {
-            return time.toString("hh:mm:ss");
-        } else {
-            return time.toString("mm:ss");
-        }
-    }
-    return "00:00";
+    QString format = m_currentItem && m_currentItem->duration().hour() > 0
+            ? "hh:mm:ss"
+            : "mm:ss";
+    return time().toString(format);
 }
 
 QTime Player::totalTime() const

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -111,6 +111,7 @@ public:
     void setTimerActive(bool active);
 
     Q_INVOKABLE void seek(double percentage);
+    void seek(QTime time);
 
     LibraryItem* currentItem() const;
 

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -76,6 +76,7 @@ public:
     QString state() const;
     int speed() const;
     double percentage() const;
+    QTime time() const;
     QString timeString() const;
     QTime totalTime() const;
     QString totalTimeString() const;
@@ -138,10 +139,10 @@ public slots:
     void seekBackward();
     void seekForward();
     void refresh();
+    void updatePlaytime();
 
 private slots:
     void receivedAnnouncement(const QVariantMap& map);
-    void updatePlaytime();
     void getRepeatShuffle();
     void getMediaProps();
 

--- a/libkodimote/player.h
+++ b/libkodimote/player.h
@@ -42,7 +42,7 @@ class Player : public QObject
     Q_PROPERTY(QString state READ state NOTIFY stateChanged)
     Q_PROPERTY(int speed READ speed NOTIFY speedChanged)
     Q_PROPERTY(double percentage READ percentage NOTIFY percentageChanged)
-    Q_PROPERTY(QString time READ time NOTIFY timeChanged)
+    Q_PROPERTY(QString timeString READ timeString NOTIFY timeChanged)
     Q_PROPERTY(QTime totalTime READ totalTime NOTIFY currentItemChanged)
     Q_PROPERTY(QString totalTimeString READ totalTimeString NOTIFY currentItemChanged)
     Q_PROPERTY(bool timerActive READ timerActive WRITE setTimerActive)
@@ -76,7 +76,7 @@ public:
     QString state() const;
     int speed() const;
     double percentage() const;
-    QString time() const;
+    QString timeString() const;
     QTime totalTime() const;
     QString totalTimeString() const;
 

--- a/libkodimote/protocolhandlers/nativeprotocolhandler.cpp
+++ b/libkodimote/protocolhandlers/nativeprotocolhandler.cpp
@@ -1,0 +1,38 @@
+#include "nativeprotocolhandler.h"
+
+#include "../kodi.h"
+#include "../videoplayer.h"
+
+NativeProtocolHandler::NativeProtocolHandler(const QString &scheme, QObject *parent) :
+    ProtocolHandler(parent),
+    m_scheme(scheme)
+{
+}
+
+QString NativeProtocolHandler::scheme() const
+{
+    return m_scheme;
+}
+
+void NativeProtocolHandler::execute(const QUrl &uri, bool queue)
+{
+    Q_UNUSED(queue)
+    PlaylistItem item;
+    item.setFile(uri.toString());
+
+    //we don't know the type of medium, that's why we don't support adding to a playlist,
+    //and can't use the audioPlayer as it always adds to the playlist and thus also depends on the type
+    //TODO: investigate if we realy need different playlists, and can't just queue without playlistId
+    Kodi::instance()->videoPlayer()->open(item);
+}
+
+void NativeProtocolHandler::registerAll(ProtocolManager *manager)
+{
+    manager->registerProtocol(new NativeProtocolHandler("http", manager));
+    manager->registerProtocol(new NativeProtocolHandler("https", manager));
+    manager->registerProtocol(new NativeProtocolHandler("smb", manager));
+    manager->registerProtocol(new NativeProtocolHandler("sftp", manager));
+    manager->registerProtocol(new NativeProtocolHandler("nfs", manager));
+    manager->registerProtocol(new NativeProtocolHandler("upnp", manager));
+    manager->registerProtocol(new NativeProtocolHandler("plugin", manager));
+}

--- a/libkodimote/protocolhandlers/nativeprotocolhandler.cpp
+++ b/libkodimote/protocolhandlers/nativeprotocolhandler.cpp
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #include "nativeprotocolhandler.h"
 
 #include "../kodi.h"

--- a/libkodimote/protocolhandlers/nativeprotocolhandler.h
+++ b/libkodimote/protocolhandlers/nativeprotocolhandler.h
@@ -1,0 +1,24 @@
+#ifndef NATIVEPROTOCOLHANDLER_H
+#define NATIVEPROTOCOLHANDLER_H
+
+#include "protocolhandler.h"
+#include "protocolmanager.h"
+
+class NativeProtocolHandler : public ProtocolHandler
+{
+    Q_OBJECT
+public:
+    explicit NativeProtocolHandler(const QString &scheme, QObject *parent = 0);
+
+    QString scheme() const;
+
+    static void registerAll(ProtocolManager *manager);
+
+public slots:
+    void execute(const QUrl &uri, bool queue = false);
+
+private:
+    QString m_scheme;
+};
+
+#endif // NATIVEPROTOCOLHANDLER_H

--- a/libkodimote/protocolhandlers/nativeprotocolhandler.h
+++ b/libkodimote/protocolhandlers/nativeprotocolhandler.h
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #ifndef NATIVEPROTOCOLHANDLER_H
 #define NATIVEPROTOCOLHANDLER_H
 

--- a/libkodimote/protocolhandlers/protocolhandler.cpp
+++ b/libkodimote/protocolhandlers/protocolhandler.cpp
@@ -1,0 +1,6 @@
+#include "protocolhandler.h"
+
+ProtocolHandler::ProtocolHandler(QObject *parent) :
+    QObject(parent)
+{
+}

--- a/libkodimote/protocolhandlers/protocolhandler.cpp
+++ b/libkodimote/protocolhandlers/protocolhandler.cpp
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #include "protocolhandler.h"
 
 ProtocolHandler::ProtocolHandler(QObject *parent) :

--- a/libkodimote/protocolhandlers/protocolhandler.h
+++ b/libkodimote/protocolhandlers/protocolhandler.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QUrl>
 
+#include "../player.h"
 #include "../playlistitem.h"
 
 class ProtocolHandler : public QObject

--- a/libkodimote/protocolhandlers/protocolhandler.h
+++ b/libkodimote/protocolhandlers/protocolhandler.h
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #ifndef PROTOCOLHANDLER_H
 #define PROTOCOLHANDLER_H
 

--- a/libkodimote/protocolhandlers/protocolhandler.h
+++ b/libkodimote/protocolhandlers/protocolhandler.h
@@ -1,0 +1,22 @@
+#ifndef PROTOCOLHANDLER_H
+#define PROTOCOLHANDLER_H
+
+#include <QObject>
+#include <QUrl>
+
+#include "../playlistitem.h"
+
+class ProtocolHandler : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ProtocolHandler(QObject *parent = 0);
+
+    virtual QString scheme() const = 0;
+
+public slots:
+    virtual void execute(const QUrl &uri, bool queue = false) = 0;
+
+};
+
+#endif // PROTOCOLHANDLER_H

--- a/libkodimote/protocolhandlers/protocolmanager.cpp
+++ b/libkodimote/protocolhandlers/protocolmanager.cpp
@@ -1,10 +1,12 @@
 #include "protocolmanager.h"
 
 #include "youtubeprotocolhandler.h"
+#include "nativeprotocolhandler.h"
 
 ProtocolManager::ProtocolManager(QObject *parent) :
     QObject(parent)
 {
+    NativeProtocolHandler::registerAll(this);
     registerProtocol(new YoutubeProtocolHandler(this));
 }
 

--- a/libkodimote/protocolhandlers/protocolmanager.cpp
+++ b/libkodimote/protocolhandlers/protocolmanager.cpp
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #include "protocolmanager.h"
 
 #include <QUrlQuery>

--- a/libkodimote/protocolhandlers/protocolmanager.cpp
+++ b/libkodimote/protocolhandlers/protocolmanager.cpp
@@ -1,5 +1,7 @@
 #include "protocolmanager.h"
 
+#include <QUrlQuery>
+
 #include "youtubeprotocolhandler.h"
 #include "nativeprotocolhandler.h"
 
@@ -27,4 +29,16 @@ ProtocolHandler *ProtocolManager::get(const QString &scheme) const
     }
 
     return m_handlers[scheme];
+}
+
+void ProtocolManager::execute(const QUrl &url)
+{
+    if (!m_handlers.contains(url.scheme())) {
+        return;
+    }
+
+    ProtocolHandler *handler = m_handlers[url.scheme()];
+
+    QUrlQuery query(url);
+    handler->execute(url, query.hasQueryItem("queue"));
 }

--- a/libkodimote/protocolhandlers/protocolmanager.cpp
+++ b/libkodimote/protocolhandlers/protocolmanager.cpp
@@ -1,0 +1,28 @@
+#include "protocolmanager.h"
+
+#include "youtubeprotocolhandler.h"
+
+ProtocolManager::ProtocolManager(QObject *parent) :
+    QObject(parent)
+{
+    registerProtocol(new YoutubeProtocolHandler(this));
+}
+
+void ProtocolManager::registerProtocol(ProtocolHandler *handler)
+{
+    m_handlers.insert(handler->scheme(), handler);
+}
+
+QList<ProtocolHandler*> ProtocolManager::list() const
+{
+    return m_handlers.values();
+}
+
+ProtocolHandler *ProtocolManager::get(const QString &scheme) const
+{
+    if (!m_handlers.contains(scheme)) {
+        return NULL;
+    }
+
+    return m_handlers[scheme];
+}

--- a/libkodimote/protocolhandlers/protocolmanager.h
+++ b/libkodimote/protocolhandlers/protocolmanager.h
@@ -1,0 +1,25 @@
+#ifndef PROTOCOLMANAGER_H
+#define PROTOCOLMANAGER_H
+
+#include <QObject>
+#include <QHash>
+
+#include "protocolhandler.h"
+
+class ProtocolManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ProtocolManager(QObject *parent = 0);
+
+    void registerProtocol(ProtocolHandler *handler);
+
+    QList<ProtocolHandler*> list() const;
+
+    ProtocolHandler *get(const QString &scheme) const;
+
+private:
+    QHash<QString, ProtocolHandler*> m_handlers;
+};
+
+#endif // PROTOCOLMANAGER_H

--- a/libkodimote/protocolhandlers/protocolmanager.h
+++ b/libkodimote/protocolhandlers/protocolmanager.h
@@ -15,8 +15,10 @@ public:
     void registerProtocol(ProtocolHandler *handler);
 
     QList<ProtocolHandler*> list() const;
-
     ProtocolHandler *get(const QString &scheme) const;
+
+    inline void execute(const QString &uri) { execute(QUrl(uri)); }
+    void execute(const QUrl &url);
 
 private:
     QHash<QString, ProtocolHandler*> m_handlers;

--- a/libkodimote/protocolhandlers/protocolmanager.h
+++ b/libkodimote/protocolhandlers/protocolmanager.h
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #ifndef PROTOCOLMANAGER_H
 #define PROTOCOLMANAGER_H
 

--- a/libkodimote/protocolhandlers/youtubeprotocolhandler.cpp
+++ b/libkodimote/protocolhandlers/youtubeprotocolhandler.cpp
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #include "youtubeprotocolhandler.h"
 
 #include <QUrlQuery>

--- a/libkodimote/protocolhandlers/youtubeprotocolhandler.cpp
+++ b/libkodimote/protocolhandlers/youtubeprotocolhandler.cpp
@@ -1,0 +1,45 @@
+#include "youtubeprotocolhandler.h"
+
+#include <QUrlQuery>
+#include "kodi.h"
+#include "videoplayer.h"
+#include "playlist.h"
+
+YoutubeProtocolHandler::YoutubeProtocolHandler(QObject *parent) :
+    ProtocolHandler(parent)
+{
+}
+
+QString YoutubeProtocolHandler::scheme() const
+{
+    return "youtube";
+}
+
+void YoutubeProtocolHandler::execute(const QUrl &uri, bool queue)
+{
+    QStringList parts = uri.path().split('/');
+    QUrlQuery query;
+    if (parts.length() == 1) {
+        query.addQueryItem("action", "play_video");
+        query.addQueryItem("videoid", parts[0]);
+    } else if (parts.length() == 2) {
+        if (parts[0] == "video") {
+            query.addQueryItem("action", "play_video");
+            query.addQueryItem("videoid", parts[1]);
+        }
+    }
+
+    if (query.isEmpty()) {
+        return;
+    }
+
+    PlaylistItem item;
+    item.setFile("plugin://plugin.video.youtube/?" + query.toString());
+
+    Player *player = Kodi::instance()->videoPlayer();
+    if (queue) {
+        player->playlist()->addItems(item);
+    } else {
+        player->open(item);
+    }
+}

--- a/libkodimote/protocolhandlers/youtubeprotocolhandler.h
+++ b/libkodimote/protocolhandlers/youtubeprotocolhandler.h
@@ -1,0 +1,19 @@
+#ifndef YOUTUBEPROTOCOLHANDLER_H
+#define YOUTUBEPROTOCOLHANDLER_H
+
+#include "protocolhandler.h"
+
+class YoutubeProtocolHandler : public ProtocolHandler
+{
+    Q_OBJECT
+public:
+    explicit YoutubeProtocolHandler(QObject *parent = 0);
+
+    QString scheme() const;
+
+public slots:
+    void execute(const QUrl &uri, bool queue = false);
+
+};
+
+#endif // YOUTUBEPROTOCOLHANDLER_H

--- a/libkodimote/protocolhandlers/youtubeprotocolhandler.h
+++ b/libkodimote/protocolhandlers/youtubeprotocolhandler.h
@@ -1,3 +1,24 @@
+/*****************************************************************************
+ * Copyright: 2011-2013 Michael Zanetti <michael_zanetti@gmx.net>            *
+ *            2014-2015 Robert Meijers <robert.meijers@gmail.com>            *
+ *                                                                           *
+ * This file is part of Kodimote                                             *
+ *                                                                           *
+ * Kodimote is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by      *
+ * the Free Software Foundation, either version 3 of the License, or         *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * Kodimote is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ ****************************************************************************/
+
 #ifndef YOUTUBEPROTOCOLHANDLER_H
 #define YOUTUBEPROTOCOLHANDLER_H
 


### PR DESCRIPTION
Fixes #37 

Implemented MPRIS2 support in the library, so that it can be used by an app using just a couple of lines of code.

- [x] Add basic API for `MediaPlayer2` and `MediaPlayer2.Player` interfaces
- [x] Send basic metadata
- [x] Support seeking etc
- [x] Hook up in Sailfish
- [x] Implement support for all media types (currently episode only)
  - [x] Add/handle paths for other types
  - [x] Expand meta data with details of other types
- [x] Implement minor missing options/properties (`LoopStatus`, `Shuffle`, `Volume`)
- [x] Implement OpenUrl support (at least basic support for some kind of `youtube://<video id>`, playback of local items would be too much work, as it needs something to stream/share the item to Kodi)

Use cases (for Sailfish) are (hopefully as all are untested):
- Playback control on lock screen, when feature is released by Jolla and hopefully uses MPRIS2
- Playback control using the Pebble watch (for example using https://github.com/smokku/pebble)
- Allowing other applications to start playback on Kodi (like [Ytplayer](https://github.com/tworaz/sailfish-ytplayer))