### PR TITLE
Add playlist support

### DIFF
--- a/libkodimote/audiolibrary.cpp
+++ b/libkodimote/audiolibrary.cpp
@@ -28,6 +28,7 @@
 #include "libraryitem.h"
 #include "addonsource.h"
 #include "shares.h"
+#include "playlists.h"
 
 AudioLibrary::AudioLibrary() :
     KodiLibrary(0)
@@ -63,6 +64,11 @@ AudioLibrary::AudioLibrary() :
     item->setPlayable(false);
     m_list.append(item);
 
+    item = new LibraryItem(tr("Playlists"), QString(), this);
+    item->setFileType("directory");
+    item->setPlayable(false);
+    m_list.append(item);
+
     item = new LibraryItem(tr("Music Add-ons"), QString(), this);
     item->setFileType("directory");
     item->setPlayable(false);
@@ -90,8 +96,10 @@ KodiModel *AudioLibrary::enterItem(int index)
     case 5:
         return new RecentItems(RecentItems::ModeAudio, RecentItems::RecentlyPlayed, this);
     case 6:
-        return new AddonSource(tr("Music Add-ons"), "music", "addons://sources/audio", this);
+        return new Playlists(tr("Audio playlists"), "music", "special://musicplaylists", this);
     case 7:
+        return new AddonSource(tr("Music Add-ons"), "music", "addons://sources/audio", this);
+    case 8:
         return new Shares("music");
     }
     return 0;

--- a/libkodimote/libkodimote.pro
+++ b/libkodimote/libkodimote.pro
@@ -75,7 +75,9 @@ SOURCES +=  kodi.cpp \
             kodihost.cpp \
             addonsource.cpp \
             profiles.cpp \
-            profileitem.cpp
+            profileitem.cpp \
+            playlists.cpp \
+            playlistcontent.cpp
 
 HEADERS += libkodimote_global.h \
            kodi.h \
@@ -132,4 +134,6 @@ HEADERS += libkodimote_global.h \
            kodihost.h \
            addonsource.h \
            profiles.h \
-           profileitem.h
+           profileitem.h \
+           playlists.h \
+           playlistcontent.h

--- a/libkodimote/playlistcontent.cpp
+++ b/libkodimote/playlistcontent.cpp
@@ -1,0 +1,43 @@
+#include "playlistcontent.h"
+
+#include "player.h"
+#include "playlist.h"
+#include "playlistitem.h"
+#include "libraryitem.h"
+
+PlaylistContent::PlaylistContent(const QString &title, const QString &mediaType, const QString &dir, KodiModel *parent) :
+    Files(mediaType, dir, parent),
+    m_title(title)
+{
+    //disable sorting, as otherwise the order in Kodi and our view would be different
+    //meaning indexes used for "playItem" are wrong etc
+    m_sort = false;
+}
+
+QString PlaylistContent::title() const
+{
+    return m_title;
+}
+
+void PlaylistContent::playItem(int index, bool resume)
+{
+    Q_UNUSED(resume)
+    PlaylistItem item;
+    item.setDirectory(m_dir);
+
+    m_player->playlist()->clear();
+    m_player->playlist()->addItems(item);
+    m_player->playItem(index);
+}
+
+void PlaylistContent::addToPlaylist(int index)
+{
+    LibraryItem *item = static_cast<LibraryItem*>(m_list.at(index));
+    PlaylistItem pItem;
+    if(item->fileType() == "file") {
+        pItem.setFile(item->fileName());
+    } else {
+        pItem.setDirectory(item->fileName());
+    }
+    m_player->playlist()->addItems(pItem);
+}

--- a/libkodimote/playlistcontent.h
+++ b/libkodimote/playlistcontent.h
@@ -1,0 +1,20 @@
+#ifndef PLAYLISTCONTENT_H
+#define PLAYLISTCONTENT_H
+
+#include "files.h"
+
+class PlaylistContent : public Files
+{
+    Q_OBJECT
+public:
+    explicit PlaylistContent(const QString &title, const QString &mediaType, const QString &dir, KodiModel *parent);
+
+    QString title() const;
+    void playItem(int index, bool resume = false);
+    void addToPlaylist(int index);
+
+private:
+    QString m_title;
+};
+
+#endif // PLAYLISTCONTENT_H

--- a/libkodimote/playlists.cpp
+++ b/libkodimote/playlists.cpp
@@ -1,0 +1,26 @@
+#include "playlists.h"
+
+#include "kodiconnection.h"
+#include "libraryitem.h"
+#include "playlistcontent.h"
+
+Playlists::Playlists(const QString &title, const QString &mediaType, const QString &dir, KodiModel *parent) :
+    Files(mediaType, dir, parent),
+    m_title(title)
+{
+}
+
+QString Playlists::title() const
+{
+    return m_title;
+}
+
+KodiModel *Playlists::enterItem(int index)
+{
+    LibraryItem *item = static_cast<LibraryItem*>(m_list.at(index));
+    if(item->fileType() == "directory") {
+        return new PlaylistContent(item->title(), m_mediaType, item->fileName(), this);
+    }
+    qDebug() << "cannot enter item of type file";
+    return 0;
+}

--- a/libkodimote/playlists.h
+++ b/libkodimote/playlists.h
@@ -1,0 +1,19 @@
+#ifndef PLAYLISTS_H
+#define PLAYLISTS_H
+
+#include "files.h"
+
+class Playlists : public Files
+{
+    Q_OBJECT
+public:
+    explicit Playlists(const QString &title, const QString &mediaType, const QString &dir, KodiModel *parent = 0);
+
+    QString title() const;
+    KodiModel *enterItem(int index);
+
+private:
+    QString m_title;
+};
+
+#endif // PLAYLISTS_H

--- a/libkodimote/videolibrary.cpp
+++ b/libkodimote/videolibrary.cpp
@@ -27,6 +27,7 @@
 #include "libraryitem.h"
 #include "addonsource.h"
 #include "shares.h"
+#include "playlists.h"
 
 VideoLibrary::VideoLibrary(KodiModel *parent) :
     KodiLibrary(parent)
@@ -48,6 +49,11 @@ VideoLibrary::VideoLibrary(KodiModel *parent) :
     m_list.append(item);
 
     item = new LibraryItem(tr("Recently added"), QString(), this);
+    item->setFileType("directory");
+    item->setPlayable(false);
+    m_list.append(item);
+
+    item = new LibraryItem(tr("Playlists"), QString(), this);
     item->setFileType("directory");
     item->setPlayable(false);
     m_list.append(item);
@@ -75,8 +81,10 @@ KodiModel *VideoLibrary::enterItem(int index)
     case 3:
         return new RecentItems(RecentItems::ModeVideo, RecentItems::RecentlyAdded, this);
     case 4:
-        return new AddonSource(tr("Video Add-ons"), "video", "addons://sources/video", this);
+        return new Playlists(tr("Video playlists"), "video", "special://videoplaylists", this);
     case 5:
+        return new AddonSource(tr("Video Add-ons"), "video", "addons://sources/video", this);
+    case 6:
         return new Shares("video");
     }
     return 0;


### PR DESCRIPTION
Add support for browsing both audio and video playlists. Fixes #62 

@paulvt What should party mode do? As far as I can see we can only set a player in "party mode" (Player.SetPartyMode, which takes an on/off value), which means we can only add it as another toggle next to shuffle and repeat. After some quick investigation it seems like we can't just get the "party mode playlist" from Kodi. As you said in your original issue, playlists are implemented as virtual folders (`special://musicplaylists` and `special://videoplaylists`), but the party mode playlist isn't returned as sub directory/file in those folders.